### PR TITLE
Date format conversions

### DIFF
--- a/formscrm.php
+++ b/formscrm.php
@@ -3,7 +3,7 @@
  * Plugin Name: FormsCRM
  * Plugin URI : https://close.technology/wordpress-plugins/formscrm/
  * Description: Connects Forms with CRM, ERP and Email Marketing.
- * Version: 4.2.1
+ * Version: 4.2.2-beta.1
  * Author: CloseTechnology
  * Author URI: https://close.technology
  * Text Domain: formscrm
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'FORMSCRM_VERSION', '4.2.1' );
+define( 'FORMSCRM_VERSION', '4.2.2-beta.1' );
 define( 'FORMSCRM_PLUGIN', __FILE__ );
 define( 'FORMSCRM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'FORMSCRM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/crm-library/class-crmlib-clientify.php
+++ b/includes/crm-library/class-crmlib-clientify.php
@@ -873,6 +873,12 @@ class CRMLIB_Clientify {
 				$contact[ $element['name'] ] = array( $element['value'] );
 			} elseif ( 'gdpr_accept' === $element['name'] || 'disclaimer' === $element['name'] ) {
 				$contact[ $element['name'] ] = empty( $element['value'] ) ? false : true;
+			} elseif ( 'birthday' === $element['name'] ) {
+				// Normalize birthday date format to YYYY-MM-DD.
+				$normalized_date = formscrm_normalize_date_format( $element['value'] );
+				if ( false !== $normalized_date ) {
+					$contact[ $element['name'] ] = $normalized_date;
+				}
 			} else {
 				$contact[ $element['name'] ] = $element['value'];
 			}

--- a/includes/formscrm-library/helpers-functions.php
+++ b/includes/formscrm-library/helpers-functions.php
@@ -435,6 +435,87 @@ if ( ! function_exists( 'formscrm_send_webhook' ) ) {
 	}
 }
 
+if ( ! function_exists( 'formscrm_normalize_date_format' ) ) {
+	/**
+	 * Normalizes date to YYYY-MM-DD format required by APIs like Clientify.
+	 *
+	 * Supported input formats:
+	 * - dd/mm/yyyy (European format)
+	 * - dd-mm-yyyy (European format with dashes)
+	 * - dd.mm.yyyy (European format with dots)
+	 * - yyyy-mm-dd (ISO format - already correct)
+	 * - yyyy/mm/dd (ISO format with slashes)
+	 * - mm/dd/yyyy (US format)
+	 * - mm-dd-yyyy (US format with dashes)
+	 * - Unix timestamps
+	 *
+	 * @param string $date_value The date value to normalize.
+	 * @return string|false Normalized date in YYYY-MM-DD format or false if invalid.
+	 */
+	function formscrm_normalize_date_format( $date_value ) {
+		if ( empty( $date_value ) ) {
+			return false;
+		}
+
+		$date_value = trim( $date_value );
+
+		// Already in correct format YYYY-MM-DD.
+		if ( preg_match( '/^\d{4}-\d{2}-\d{2}$/', $date_value ) ) {
+			return $date_value;
+		}
+
+		// Handle Unix timestamp.
+		if ( is_numeric( $date_value ) && strlen( $date_value ) >= 8 ) {
+			$timestamp = (int) $date_value;
+			$date      = gmdate( 'Y-m-d', $timestamp );
+			if ( false !== $date ) {
+				return $date;
+			}
+		}
+
+		// European format: dd/mm/yyyy or dd-mm-yyyy or dd.mm.yyyy.
+		if ( preg_match( '/^(\d{1,2})[\/\-\.](\d{1,2})[\/\-\.](\d{4})$/', $date_value, $matches ) ) {
+			$day   = (int) $matches[1];
+			$month = (int) $matches[2];
+			$year  = (int) $matches[3];
+
+			// Validate date components.
+			if ( $day > 31 || $month > 12 ) {
+				// Could be US format mm/dd/yyyy, try swapping.
+				if ( $month <= 31 && $day <= 12 ) {
+					$temp  = $day;
+					$day   = $month;
+					$month = $temp;
+				}
+			}
+
+			// Validate the date.
+			if ( checkdate( $month, $day, $year ) ) {
+				return sprintf( '%04d-%02d-%02d', $year, $month, $day );
+			}
+		}
+
+		// ISO format with slashes: yyyy/mm/dd.
+		if ( preg_match( '/^(\d{4})[\/](\d{1,2})[\/](\d{1,2})$/', $date_value, $matches ) ) {
+			$year  = (int) $matches[1];
+			$month = (int) $matches[2];
+			$day   = (int) $matches[3];
+
+			if ( checkdate( $month, $day, $year ) ) {
+				return sprintf( '%04d-%02d-%02d', $year, $month, $day );
+			}
+		}
+
+		// Try PHP's strtotime as last resort for other formats.
+		$timestamp = strtotime( $date_value );
+		if ( false !== $timestamp && -1 !== $timestamp ) {
+			return gmdate( 'Y-m-d', $timestamp );
+		}
+
+		return false;
+	}
+}
+
 if ( ! function_exists( 'formscrm_get_svg_icon' ) ) {
 	/**
 	 * Get SVG icon content.

--- a/readme.txt
+++ b/readme.txt
@@ -131,7 +131,7 @@ WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
 = 4.2.2 =
-*  Added date conversion in Clientify.
+*  Added date conversion in Clientify for birthday field.
 
 = 4.2.1 =
 *  Hotfix: Error not sending correctly entry id in webhook.

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,9 @@ WordPress installation and then activate the Plugin from Plugins page.
 [Official Repository GitHub](https://github.com/closemarketing/formscrm/)
 
 == Changelog ==
+= 4.2.2 =
+*  Added date conversion in Clientify.
+
 = 4.2.1 =
 *  Hotfix: Error not sending correctly entry id in webhook.
 

--- a/tests/Unit/test-helpers-functions.php
+++ b/tests/Unit/test-helpers-functions.php
@@ -424,4 +424,153 @@ class HelpersFunctionsTest extends WP_UnitTestCase {
 		$result = formscrm_get_api_class( 'Invalid CRM' );
 		$this->assertNull( $result );
 	}
+
+	/**
+	 * Test formscrm_normalize_date_format with European format dd/mm/yyyy.
+	 */
+	public function test_normalize_date_format_european_slash() {
+		$result = formscrm_normalize_date_format( '25/12/1990' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		$result = formscrm_normalize_date_format( '01/01/2000' );
+		$this->assertEquals( '2000-01-01', $result );
+
+		$result = formscrm_normalize_date_format( '15/06/1985' );
+		$this->assertEquals( '1985-06-15', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with European format dd-mm-yyyy.
+	 */
+	public function test_normalize_date_format_european_dash() {
+		$result = formscrm_normalize_date_format( '25-12-1990' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		$result = formscrm_normalize_date_format( '01-01-2000' );
+		$this->assertEquals( '2000-01-01', $result );
+
+		$result = formscrm_normalize_date_format( '15-06-1985' );
+		$this->assertEquals( '1985-06-15', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with European format dd.mm.yyyy.
+	 */
+	public function test_normalize_date_format_european_dot() {
+		$result = formscrm_normalize_date_format( '25.12.1990' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		$result = formscrm_normalize_date_format( '01.01.2000' );
+		$this->assertEquals( '2000-01-01', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with ISO format yyyy-mm-dd.
+	 */
+	public function test_normalize_date_format_iso() {
+		$result = formscrm_normalize_date_format( '1990-12-25' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		$result = formscrm_normalize_date_format( '2000-01-01' );
+		$this->assertEquals( '2000-01-01', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with ISO format yyyy/mm/dd.
+	 */
+	public function test_normalize_date_format_iso_slash() {
+		$result = formscrm_normalize_date_format( '1990/12/25' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		$result = formscrm_normalize_date_format( '2000/01/01' );
+		$this->assertEquals( '2000-01-01', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with US format mm/dd/yyyy.
+	 * When day value > 12, it's clearly US format.
+	 */
+	public function test_normalize_date_format_us_format() {
+		// When month value > 12, swap is applied.
+		$result = formscrm_normalize_date_format( '06/25/1985' );
+		$this->assertEquals( '1985-06-25', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with Unix timestamp.
+	 */
+	public function test_normalize_date_format_unix_timestamp() {
+		// Timestamp for 1990-12-25 00:00:00 UTC.
+		$result = formscrm_normalize_date_format( '662083200' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		// Timestamp for 2000-01-01 00:00:00 UTC.
+		$result = formscrm_normalize_date_format( '946684800' );
+		$this->assertEquals( '2000-01-01', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with empty value.
+	 */
+	public function test_normalize_date_format_empty() {
+		$result = formscrm_normalize_date_format( '' );
+		$this->assertFalse( $result );
+
+		$result = formscrm_normalize_date_format( null );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with invalid date.
+	 */
+	public function test_normalize_date_format_invalid() {
+		$result = formscrm_normalize_date_format( 'invalid-date' );
+		$this->assertFalse( $result );
+
+		$result = formscrm_normalize_date_format( 'abc' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with single digit day and month.
+	 */
+	public function test_normalize_date_format_single_digits() {
+		$result = formscrm_normalize_date_format( '5/6/1990' );
+		$this->assertEquals( '1990-06-05', $result );
+
+		$result = formscrm_normalize_date_format( '1-2-2000' );
+		$this->assertEquals( '2000-02-01', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with whitespace.
+	 */
+	public function test_normalize_date_format_whitespace() {
+		$result = formscrm_normalize_date_format( '  25/12/1990  ' );
+		$this->assertEquals( '1990-12-25', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with text date formats.
+	 */
+	public function test_normalize_date_format_text_formats() {
+		$result = formscrm_normalize_date_format( 'December 25, 1990' );
+		$this->assertEquals( '1990-12-25', $result );
+
+		$result = formscrm_normalize_date_format( '25 Dec 1990' );
+		$this->assertEquals( '1990-12-25', $result );
+	}
+
+	/**
+	 * Test formscrm_normalize_date_format with invalid day/month values.
+	 */
+	public function test_normalize_date_format_invalid_day_month() {
+		// Invalid day 32.
+		$result = formscrm_normalize_date_format( '32/12/1990' );
+		$this->assertFalse( $result );
+
+		// Invalid month 13.
+		$result = formscrm_normalize_date_format( '25/13/1990' );
+		$this->assertFalse( $result );
+	}
 }


### PR DESCRIPTION
Add date normalization for Clientify API's birthday field to support various input formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-336bbdda-d18c-4097-a822-cedd7b47cadf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-336bbdda-d18c-4097-a822-cedd7b47cadf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

