### PR TITLE
Opciones de actualización de contacto

### DIFF
--- a/docs/issues/clientify-api-v2-migration.md
+++ b/docs/issues/clientify-api-v2-migration.md
@@ -1,0 +1,163 @@
+# Migrate Clientify Integration from API v1 to API v2
+
+## Summary
+
+Migrate the existing Clientify CRM integration from the legacy API v1 (`https://api.clientify.net/v1/`) to the new API v2 documented at https://newapi.clientify.com/#c4871c63-5032-4ad8-94e5-3b0f14106d4d
+
+## Motivation
+
+Clientify has released a new version of their public API (v2). The current integration relies entirely on v1 endpoints which may be deprecated in the future. Migrating ensures continued compatibility, access to new features, and long-term support.
+
+## Current v1 Implementation
+
+### Base URL
+```
+https://api.clientify.net/v1/
+```
+
+### Authentication
+- Header: `Authorization: Token {apikey}`
+- Credential stored in: `fc_crm_apipassword`
+
+### Endpoints Currently Used
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `settings/my-account/` | GET | Login / credential validation |
+| `custom-fields/` | GET | Fetch custom fields (paginated) |
+| `contacts` | POST | Create contact |
+| `companies` | POST | Create company |
+| `deals` | POST | Create deal |
+| `deals/{id}/tags/` | POST | Add tags to a deal |
+| `deals/{id}/products/` | PUT | Add products to a deal |
+| `products/?sku={sku}` | GET | Lookup product by SKU |
+
+### Files Affected
+
+| File | Description |
+|------|-------------|
+| `includes/crm-library/class-crmlib-clientify.php` | Core API library (all HTTP calls, authentication, CRUD) |
+| `includes/formscrm-library/class-forms-clientify.php` | Clientify-specific form integrations (visitor key, cookie fields) |
+| `includes/formscrm-library/helpers-library-crm.php` | Visitor key session handling |
+| `includes/formscrm-library/js/clientify-field.js` | Frontend JS for visitor key cookie |
+| `formscrm.php` | Clientify registration (CRM choices, credential dependencies) |
+| `tests/API/test-clientify.php` | PHPUnit tests |
+| `tests/Data/clientify-login.json` | Mock login response |
+| `tests/Data/clientify-custom-fields.json` | Mock custom fields response |
+| `tests/clientify.php` | Manual API test script |
+
+### Current Data Structures
+
+**Contact payload:**
+- Standard fields: `first_name`, `last_name`, `email`, `phone`, `company`, `status`, `tags`, etc.
+- `custom_fields`: `[{"field": "field_name", "value": "..."}]`
+- `emails`: `[{"type": 1|2|3, "email": "..."}]` (1=Work, 2=Personal, 3=Other)
+- `phones`: `[{"type": 2|3|4|5|6, "phone": "..."}]`
+- `websites`: `[{"type": 1-5, "website": "..."}]`
+- `addresses`: `[{"street", "city", "state", "country", "postal_code", "type"}]`
+- Boolean fields: `gdpr_accept`, `disclaimer`
+- Date fields: `birthday` (normalized to `YYYY-MM-DD`)
+
+**Deal payload:**
+- `contact` or `company`: URL reference (e.g. `https://api.clientify.net/v1/contacts/{id}/`)
+- `name`, `amount`, `expected_closed_date`, `pipeline`, `custom_fields`
+- Tags via separate `POST deals/{id}/tags/`
+- Products via separate `PUT deals/{id}/products/`
+
+## Migration Tasks
+
+### 1. Review API v2 Documentation
+- [ ] Thoroughly review the new API v2 documentation at https://newapi.clientify.com/#c4871c63-5032-4ad8-94e5-3b0f14106d4d
+- [ ] Document all endpoint changes (URLs, methods, request/response formats)
+- [ ] Identify authentication changes (Token vs Bearer, new headers, OAuth, etc.)
+- [ ] Identify new/removed/renamed fields
+- [ ] Identify pagination changes (current v1 uses `next`/`previous` with `results` array)
+- [ ] Check rate limiting changes
+
+### 2. Update Base URL and Authentication (`class-crmlib-clientify.php`)
+- [ ] Update base URL from `https://api.clientify.net/v1/` to the v2 base URL
+- [ ] Update authentication headers if the format has changed
+- [ ] Update the `get()` method with new pagination format if changed
+- [ ] Update the `request()` method — **fix existing bug**: currently uses `wp_remote_post()` for all methods including PUT; should use `wp_remote_request()` with proper `method` parameter
+
+### 3. Update Login / Validation (`login()`)
+- [ ] Update the login endpoint (currently `settings/my-account/`)
+- [ ] Update response validation logic (currently checks `$get_result['data']['count'] > 0`)
+
+### 4. Update Custom Fields Retrieval (`list_fields()`)
+- [ ] Update custom fields endpoint (currently `custom-fields/`)
+- [ ] Adapt to new response format if `content_type` field naming has changed
+- [ ] Verify field types mapping still works (`field_type`, `field_type_display`)
+
+### 5. Update Contact Creation (`create_entry()`)
+- [ ] Update contacts endpoint (currently `POST contacts`)
+- [ ] Adapt contact payload structure to v2 format
+- [ ] Verify `emails`, `phones`, `websites`, `addresses` array structures
+- [ ] Verify `custom_fields` format
+- [ ] Verify `tags` handling
+- [ ] Verify boolean fields (`gdpr_accept`, `disclaimer`)
+- [ ] Verify date field format (`birthday`)
+- [ ] Check if `visitor_key` handling has changed
+
+### 6. Update Company Creation
+- [ ] Update companies endpoint (currently `POST companies`)
+- [ ] Adapt company payload structure to v2 format
+
+### 7. Update Deal Creation and Related Operations
+- [ ] Update deals endpoint (currently `POST deals`)
+- [ ] Update deal reference format — currently uses full URL (`https://api.clientify.net/v1/contacts/{id}/`), verify if v2 uses IDs directly
+- [ ] Update deal tags endpoint (currently `POST deals/{id}/tags/`)
+- [ ] Update deal products endpoint (currently `PUT deals/{id}/products/`)
+- [ ] Update product lookup by SKU (currently `GET products/?sku={sku}`)
+- [ ] Fix `deal|pipeline_desc` vs `deal|pipeline_name` mismatch in field mapping
+
+### 8. Update Modules List (`list_modules()`)
+- [ ] Verify available modules in v2 (Contacts, Companies, Deals)
+- [ ] Check if new modules have been added
+
+### 9. Fix Existing Known Bugs During Migration
+- [ ] **PUT method bug**: `request()` uses `wp_remote_post()` for all HTTP methods. Change to `wp_remote_request()` for proper PUT/PATCH support
+- [ ] **Error body access**: Line ~53-54 in `get()` accesses `$result_api['body']` directly instead of using `wp_remote_retrieve_body($result_api)`
+- [ ] **Pipeline field mismatch**: `list_fields()` exposes `deal|pipeline_desc` but `create_entry()` only handles `deal|pipeline_name`
+
+### 10. Update Tests
+- [ ] Update mock response files (`tests/Data/clientify-login.json`, `tests/Data/clientify-custom-fields.json`) to match v2 response format
+- [ ] Update test assertions if response structure changes
+- [ ] Add new tests for any new v2-specific functionality
+- [ ] Update manual test script (`tests/clientify.php`)
+- [ ] Add tests for the fixed bugs (PUT method, error handling)
+
+### 11. Update Visitor Key / Cookie Handling
+- [ ] Verify if Clientify's visitor tracking (`vk` cookie) mechanism has changed in v2
+- [ ] Update `helpers-library-crm.php` if session variable handling changes
+- [ ] Update `js/clientify-field.js` if cookie name or format changes
+
+### 12. Backwards Compatibility
+- [ ] Consider if existing users need a migration path or if v2 is a drop-in replacement
+- [ ] Ensure existing feed configurations (`fc_crm_apipassword`, `fc_crm_module`) remain compatible
+- [ ] If API key format changes, provide clear admin notice and migration instructions
+- [ ] Test with all form integrations (Gravity Forms, CF7, WPForms, Elementor, WooCommerce)
+
+## Acceptance Criteria
+
+- [ ] All current Clientify functionality works with the new API v2
+- [ ] Login/authentication validates correctly against v2
+- [ ] Custom fields are fetched and displayed correctly in field mapping UI
+- [ ] Contact creation works with all field types (standard, custom, emails, phones, addresses, websites)
+- [ ] Company creation works correctly
+- [ ] Deal creation works (with contact/company association, tags, and products)
+- [ ] Visitor key tracking continues to work
+- [ ] All PHPUnit tests pass with updated mock data
+- [ ] No regressions in existing form plugin integrations (GF, CF7, WPForms, Elementor, WooCommerce)
+- [ ] Error handling and logging work correctly
+- [ ] Retry mechanism (`formscrm_retry_failed_entry`) works with new endpoints
+- [ ] Existing bugs (PUT method, error body access, pipeline mismatch) are fixed
+- [ ] `composer lint` and `composer phpstan` pass
+
+## API v2 Documentation Reference
+
+https://newapi.clientify.com/#c4871c63-5032-4ad8-94e5-3b0f14106d4d
+
+## Labels
+
+`enhancement`, `api-migration`, `clientify`

--- a/formscrm.php
+++ b/formscrm.php
@@ -3,7 +3,7 @@
  * Plugin Name: FormsCRM
  * Plugin URI : https://close.technology/wordpress-plugins/formscrm/
  * Description: Connects Forms with CRM, ERP and Email Marketing.
- * Version: 4.3.1
+ * Version: 4.3.2-beta.1
  * Author: CloseTechnology
  * Author URI: https://close.technology
  * Text Domain: formscrm
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'FORMSCRM_VERSION', '4.3.1' );
+define( 'FORMSCRM_VERSION', '4.3.2-beta.1' );
 define( 'FORMSCRM_PLUGIN', __FILE__ );
 define( 'FORMSCRM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'FORMSCRM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/crm-library/class-crmlib-clientify.php
+++ b/includes/crm-library/class-crmlib-clientify.php
@@ -2,12 +2,13 @@
 /**
  * Clientify connect library
  *
- * Has functions to login, list fields and create lead
+ * Has functions to login, list fields and create lead.
+ * Uses Clientify API v2: https://newapi.clientify.com/
  *
  * @author   closemarketing
  * @category Functions
  * @package  Gravityforms CRM
- * @version  1.0.0
+ * @version  2.0.0
  *
  * phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
  */
@@ -17,10 +18,18 @@
  */
 class CRMLIB_Clientify {
  // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Legacy class name, changing would break compatibility.
+
+	/**
+	 * Clientify API v2 base URL.
+	 *
+	 * @var string
+	 */
+	private $api_url = 'https://api-plus.clientify.com/v2/';
+
 	/**
 	 * Gets information from Clientify CRM
 	 *
-	 * @param string $url URL for module.
+	 * @param string $url    URL for module.
 	 * @param string $apikey API Authentication.
 	 *
 	 * @return array
@@ -38,20 +47,21 @@ class CRMLIB_Clientify {
 			),
 			'timeout' => 120,
 		);
-		// Loop.
+
 		$next          = true;
 		$results_value = array();
-		$url           = 'https://api.clientify.net/v1/' . $url;
+		$url           = $this->api_url . $url;
 
 		while ( $next ) {
 			$result_api  = wp_remote_get( $url, $args );
-			$results     = json_decode( wp_remote_retrieve_body( $result_api ), true );
+			$body_raw    = wp_remote_retrieve_body( $result_api );
+			$results     = json_decode( $body_raw, true );
 			$code_status = (int) wp_remote_retrieve_response_code( $result_api );
 			$code        = (int) round( $code_status / 100, 0 );
 
 			if ( 2 !== $code ) {
-				$message = implode( ' ', $result_api['response'] ) . ' ';
-				$body    = json_decode( $result_api['body'], true );
+				$message = $code_status . ' ';
+				$body    = json_decode( $body_raw, true );
 
 				if ( is_array( $body ) ) {
 					foreach ( $body as $key => $value ) {
@@ -81,17 +91,19 @@ class CRMLIB_Clientify {
 			'data'   => $results,
 		);
 	}
+
 	/**
-	 * Posts information from Holded CRM
+	 * Sends a request to Clientify API.
 	 *
 	 * @param string $module   URL for module.
-	 * @param string $bodypost Params to send to API.
+	 * @param array  $bodypost Params to send to API.
 	 * @param string $apikey   API Authentication.
-	 * @param string $method   Method to use.
+	 * @param string $method   HTTP method to use.
 	 * @return array
 	 */
 	private function request( $module, $bodypost, $apikey, $method = 'POST' ) {
-		$args   = array(
+		$url  = $this->api_url . strtolower( $module );
+		$args = array(
 			'headers' => array(
 				'Authorization' => 'Token ' . $apikey,
 				'Content-Type'  => 'application/json',
@@ -100,13 +112,14 @@ class CRMLIB_Clientify {
 			'timeout' => 120,
 			'body'    => wp_json_encode( $bodypost ),
 		);
-		$url    = 'https://api.clientify.net/v1/' . strtolower( $module );
-		$result = wp_remote_post( $url, $args );
-		$code   = isset( $result['response']['code'] ) ? (int) round( $result['response']['code'] / 100, 0 ) : 0;
+
+		$result   = wp_remote_request( $url, $args );
+		$body_raw = wp_remote_retrieve_body( $result );
+		$code     = (int) round( (int) wp_remote_retrieve_response_code( $result ) / 100, 0 );
 
 		if ( 2 !== $code ) {
-			$message = implode( ' ', $result['response'] ) . ' ';
-			$body    = json_decode( $result['body'], true );
+			$message = wp_remote_retrieve_response_code( $result ) . ' ';
+			$body    = json_decode( $body_raw, true );
 			if ( is_array( $body ) ) {
 				foreach ( $body as $key => $value ) {
 					$message_value = is_array( $value ) ? implode( '.', $value ) : $value;
@@ -121,10 +134,9 @@ class CRMLIB_Clientify {
 				'query'  => wp_json_encode( $bodypost ),
 			);
 		} else {
-			$body = wp_remote_retrieve_body( $result );
 			return array(
 				'status' => 'ok',
-				'data'   => json_decode( $body, true ),
+				'data'   => json_decode( $body_raw, true ),
 			);
 		}
 	}
@@ -136,14 +148,27 @@ class CRMLIB_Clientify {
 	 * @return false or id     returns false if cannot login and string if gets token
 	 */
 	public function login( $settings ) {
-		$apikey     = isset( $settings['fc_crm_apipassword'] ) ? $settings['fc_crm_apipassword'] : '';
-		$get_result = $this->get( 'settings/my-account/', $apikey );
-
-		if ( $apikey && isset( $get_result['data']['count'] ) && $get_result['data']['count'] > 0 ) {
-			return true;
-		} else {
+		$apikey = isset( $settings['fc_crm_apipassword'] ) ? $settings['fc_crm_apipassword'] : '';
+		if ( ! $apikey ) {
 			return false;
 		}
+
+		$args = array(
+			'headers' => array(
+				'Authorization' => 'Token ' . $apikey,
+			),
+			'timeout' => 120,
+		);
+
+		$result      = wp_remote_get( $this->api_url . 'me/', $args );
+		$body        = json_decode( wp_remote_retrieve_body( $result ), true );
+		$code_status = (int) wp_remote_retrieve_response_code( $result );
+
+		if ( 200 === $code_status && ! empty( $body['id'] ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -380,15 +405,17 @@ class CRMLIB_Clientify {
 	 */
 	private function get_fields_email_phones() {
 		$fields = array();
-		$types  = array(
+
+		// Email types: 1=Work, 2=Personal, 3=Other, 4=Main.
+		$email_types = array(
 			1 => __( 'Work', 'formscrm' ),
 			2 => __( 'Personal', 'formscrm' ),
 			3 => __( 'Other', 'formscrm' ),
+			4 => __( 'Main', 'formscrm' ),
 		);
 
-		// Emails.
 		array_walk(
-			$types,
+			$email_types,
 			function ( $type, $key ) use ( &$fields ) {
 				$fields[] = array(
 					'name'     => 'emails|' . $key,
@@ -398,7 +425,9 @@ class CRMLIB_Clientify {
 			}
 		);
 
-		$types = array(
+		// Phone types from Clientify API: Main, Mobile, Work, Home, Fax, Other.
+		$phone_types = array(
+			1 => __( 'Main', 'formscrm' ),
 			2 => __( 'Mobile', 'formscrm' ),
 			3 => __( 'Work', 'formscrm' ),
 			4 => __( 'Home', 'formscrm' ),
@@ -406,9 +435,8 @@ class CRMLIB_Clientify {
 			6 => __( 'Other', 'formscrm' ),
 		);
 
-		// Phones.
 		array_walk(
-			$types,
+			$phone_types,
 			function ( $type, $key ) use ( &$fields ) {
 				$fields[] = array(
 					'name'     => 'phones|' . $key,
@@ -726,6 +754,21 @@ class CRMLIB_Clientify {
 			$fields[] = array(
 				'name'     => 'deal|pipeline_desc',
 				'label'    => __( 'Pipeline Name', 'formscrm' ),
+				'tooltip'  => __( 'Name of the pipeline (pipeline_desc).', 'formscrm' ),
+				'required' => false,
+			);
+
+			$fields[] = array(
+				'name'     => 'deal|pipeline_id',
+				'label'    => __( 'Pipeline ID', 'formscrm' ),
+				'tooltip'  => __( 'Numeric ID of the pipeline.', 'formscrm' ),
+				'required' => false,
+			);
+
+			$fields[] = array(
+				'name'     => 'deal|pipeline_stage_desc',
+				'label'    => __( 'Pipeline Stage Name', 'formscrm' ),
+				'tooltip'  => __( 'Name of the pipeline stage.', 'formscrm' ),
 				'required' => false,
 			);
 
@@ -748,36 +791,35 @@ class CRMLIB_Clientify {
 			);
 		}
 
-		// Get Custom Fields.
-		$equivalent_module = array(
-			'contacts'        => array( 'contact', 'contacts | contact' ),
-			'companies'       => array( 'company', 'companies | company' ),
-			'contacts-deals'  => array( 'deal', 'contact', 'deals | deal', 'contacts | contact' ),
-			'companies-deals' => array( 'deal', 'contact', 'deals | deal', 'contacts | contact' ),
+		// Fetch custom fields by object_type.
+		$object_types_map = array(
+			'contacts'        => array( 'contacts' ),
+			'companies'       => array( 'companies' ),
+			'contacts-deals'  => array( 'contacts', 'deals' ),
+			'companies-deals' => array( 'companies', 'deals' ),
 		);
-		$label_module      = array(
-			'contact'             => __( 'Contact', 'formscrm' ),
-			'company'             => __( 'Company', 'formscrm' ),
-			'deal'                => __( 'Deal', 'formscrm' ),
-			'contacts | contact'  => __( 'Contact', 'formscrm' ),
-			'companies | company' => __( 'Company', 'formscrm' ),
-			'deals | deal'        => __( 'Deal', 'formscrm' ),
+		$label_map        = array(
+			'contacts'  => __( 'Contact', 'formscrm' ),
+			'companies' => __( 'Company', 'formscrm' ),
+			'deals'     => __( 'Deal', 'formscrm' ),
 		);
 
-		$result_api = $this->get( 'custom-fields/', $apikey );
-		if ( isset( $result_api['status'] ) && 'ok' === $result_api['status'] && isset( $result_api['data']['results'] ) ) {
-			foreach ( $result_api['data']['results'] as $custom_field ) {
-				if ( isset( $equivalent_module[ $module_slug ] ) && in_array( $custom_field['content_type'], $equivalent_module[ $module_slug ], true ) ) {
-					$key  = 'deals | deal' === $custom_field['content_type'] ? 'deal|' : '';
-					$key .= 'custom_fields|' . $custom_field['name'];
+		if ( isset( $object_types_map[ $module_slug ] ) ) {
+			foreach ( $object_types_map[ $module_slug ] as $object_type ) {
+				$result_api = $this->get( 'custom-fields/?object_type=' . $object_type, $apikey );
+				if ( isset( $result_api['status'] ) && 'ok' === $result_api['status'] && isset( $result_api['data']['results'] ) ) {
+					foreach ( $result_api['data']['results'] as $custom_field ) {
+						$key  = 'deals' === $object_type ? 'deal|' : '';
+						$key .= 'custom_fields|' . $custom_field['name'];
 
-					$label = isset( $label_module[ $custom_field['content_type'] ] ) ? $label_module[ $custom_field['content_type'] ] . ': ' : '';
+						$label = isset( $label_map[ $object_type ] ) ? $label_map[ $object_type ] . ': ' : '';
 
-					$fields[] = array(
-						'name'     => $key,
-						'label'    => $label . $custom_field['name'],
-						'required' => false,
-					);
+						$fields[] = array(
+							'name'     => $key,
+							'label'    => $label . $custom_field['name'],
+							'required' => false,
+						);
+					}
 				}
 			}
 		}
@@ -820,12 +862,12 @@ class CRMLIB_Clientify {
 					$deal_tags = $element['value'];
 				} elseif ( 'deal|expected_closed_date_days' === $element['name'] ) {
 					$deal['expected_closed_date'] = gmdate( 'Y-m-d', strtotime( '+' . (int) $element['value'] . ' days' ) );
-				} elseif ( 'deal|pipeline_name' === $element['name'] ) {
-					// Pipeline URL functionality not yet implemented.
-					// For now, use the pipeline name directly if provided.
-					if ( ! empty( $element['value'] ) ) {
-						$deal['pipeline'] = $element['value'];
-					}
+				} elseif ( 'deal|pipeline_id' === $element['name'] ) {
+					$deal['pipeline_id'] = (int) $element['value'];
+				} elseif ( 'deal|pipeline_desc' === $element['name'] ) {
+					$deal['pipeline_desc'] = $element['value'];
+				} elseif ( 'deal|pipeline_stage_desc' === $element['name'] ) {
+					$deal['pipeline_stage_desc'] = $element['value'];
 				} else {
 					$deal_field             = explode( '|', $element['name'] );
 					$deal[ $deal_field[1] ] = $element['value'];
@@ -890,7 +932,7 @@ class CRMLIB_Clientify {
 			$contact['tags'] = array_values( array_filter( $contact_tags ) );
 		}
 
-		$result = $this->request( $module, $contact, $apikey );
+		$result = $this->request( $module . '/', $contact, $apikey );
 		if ( 'ok' === $result['status'] ) {
 			$contact_id      = isset( $result['data']['id'] ) ? $result['data']['id'] : '';
 			$response_result = array(
@@ -899,30 +941,24 @@ class CRMLIB_Clientify {
 				'id'      => $contact_id,
 			);
 
-			// Crea ahora la oportunidad.
+			// Create deal linked to the contact/company.
 			if ( ! empty( $deal ) ) {
-				$deal_products = array();
 				if ( ! empty( $deal_product_skus ) ) {
 					$res_products = $this->extract_deal_products( $deal_product_skus, $apikey );
 					if ( ! empty( $res_products['data'] ) ) {
-						$deal_products  = $res_products['data'];
-						$deal['amount'] = ! empty( $res_products['total'] ) ? $res_products['total'] : 0;
+						$deal['products'] = $res_products['data'];
+						$deal['amount']   = ! empty( $res_products['total'] ) ? $res_products['total'] : 0;
 					}
 				}
-				// Set default values for key and slug.
-				$key  = 'contact';
-				$slug = 'contacts';
 
+				// V2 uses ID-based references instead of URL-based.
 				if ( 'contacts' === $module ) {
-					$key  = 'contact';
-					$slug = 'contacts';
+					$deal['contact_id'] = (int) $contact_id;
 				} elseif ( 'companies' === $module ) {
-					$key  = 'company';
-					$slug = 'companies';
+					$deal['company_id'] = (int) $contact_id;
 				}
-				$deal[ $key ]   = "https://api.clientify.net/v1/$slug/$contact_id/";
 				$deal['amount'] = isset( $deal['amount'] ) ? $deal['amount'] : 0;
-				$result         = $this->request( 'deals', $deal, $apikey );
+				$result         = $this->request( 'deals/', $deal, $apikey );
 				if ( 'ok' === $result['status'] ) {
 					$response_result['id'] = sprintf(
 						/* translators: %1$s: Contact ID, %2$s: Deal ID */
@@ -933,7 +969,7 @@ class CRMLIB_Clientify {
 				}
 
 				// Add tags to deal.
-				if ( ! empty( $deal_tags ) ) {
+				if ( ! empty( $deal_tags ) && isset( $result['data']['id'] ) ) {
 					$deal_tags_raw = explode( ',', $deal_tags );
 					$deal_id       = $result['data']['id'];
 
@@ -960,13 +996,6 @@ class CRMLIB_Clientify {
 						$response_result['message'] .= ' ' . $result_deal_tag;
 					}
 				}
-
-				// Add products to deal.
-				if ( ! empty( $deal_products ) && isset( $res_products['data'] ) ) {
-					$result = $this->request( 'deals/' . $result['data']['id'] . '/products/', $res_products['data'], $apikey, 'PUT' );
-
-					$response_result['message'] .= ' ' . $result['message'] . '.';
-				}
 				$last_module = 'deal';
 			}
 		} else {
@@ -984,26 +1013,29 @@ class CRMLIB_Clientify {
 	}
 
 	/**
-	 * Extracts deal products from a string of SKUs and get Clientify schema
+	 * Extracts deal products from a string of SKUs and get Clientify schema.
 	 *
 	 * @param string $deal_product_skus The string of SKUs separated by commas.
 	 * @param string $apikey            The API key.
-	 * @return array The array of deal products
+	 * @return array The array of deal products in v2 format.
 	 */
 	private function extract_deal_products( $deal_product_skus, $apikey ) {
 		$skus          = explode( ',', $deal_product_skus );
 		$deal_products = array();
 		$deal_total    = 0;
 		foreach ( $skus as $sku ) {
+			$sku         = trim( $sku );
 			$res_product = $this->get( 'products/?sku=' . $sku, $apikey );
 			if ( 'ok' === $res_product['status'] && isset( $res_product['data']['results'][0]['id'] ) ) {
+				$product       = $res_product['data']['results'][0];
+				$product_price = ! empty( $product['price'] ) ? (float) $product['price'] : 0;
+
 				$deal_products[] = array(
-					'product'  => $res_product['data']['results'][0]['id'],
-					'quantity' => 1,
+					'product_id' => $product['id'],
+					'price'      => $product_price,
+					'quantity'   => 1,
 				);
-				if ( ! empty( $res_product['data']['results'][0]['price'] ) ) {
-					$deal_total += $res_product['data']['results'][0]['price'];
-				}
+				$deal_total     += $product_price;
 			}
 		}
 		return array(

--- a/includes/crm-library/class-crmlib-clientify.php
+++ b/includes/crm-library/class-crmlib-clientify.php
@@ -613,6 +613,13 @@ class CRMLIB_Clientify {
 			);
 
 			$fields[] = array(
+				'name'     => 'marketing_status',
+				'label'    => __( 'Marketing Status', 'formscrm' ),
+				'tooltip'  => __( '1=Sales Contact, 2=Marketing Contact.', 'formscrm' ),
+				'required' => false,
+			);
+
+			$fields[] = array(
 				'name'     => 'birthday',
 				'label'    => __( 'Birthday date', 'formscrm' ),
 				'required' => false,
@@ -915,6 +922,8 @@ class CRMLIB_Clientify {
 				$contact[ $element['name'] ] = array( $element['value'] );
 			} elseif ( 'gdpr_accept' === $element['name'] || 'disclaimer' === $element['name'] ) {
 				$contact[ $element['name'] ] = empty( $element['value'] ) ? false : true;
+			} elseif ( 'marketing_status' === $element['name'] ) {
+				$contact['marketing_status'] = (int) $element['value'];
 			} elseif ( 'birthday' === $element['name'] ) {
 				// Normalize birthday date format to YYYY-MM-DD.
 				$normalized_date = formscrm_normalize_date_format( $element['value'] );

--- a/includes/crm-library/class-crmlib-clientify.php
+++ b/includes/crm-library/class-crmlib-clientify.php
@@ -704,6 +704,80 @@ class CRMLIB_Clientify {
 	}
 
 	/**
+	 * Searches for an existing contact or company by a given field.
+	 *
+	 * @param string $module    CRM module: 'contacts' or 'companies'.
+	 * @param string $update_by Strategy key: 'email', 'phone', or 'tax_id'.
+	 * @param string $value     Value to search for.
+	 * @param string $apikey    API authentication token.
+	 * @return int|false CRM record ID if found, false otherwise.
+	 */
+	private function search_contact( $module, $update_by, $value, $apikey ) {
+		if ( empty( $value ) ) {
+			return false;
+		}
+
+		$field_map = array(
+			'email'  => 'email',
+			'phone'  => 'phone',
+			'tax_id' => 'taxpayer_identification_number',
+		);
+
+		if ( ! isset( $field_map[ $update_by ] ) ) {
+			return false;
+		}
+
+		$result = $this->request(
+			$module . '/',
+			array(
+				$field_map[ $update_by ] => $value,
+				'fields'                 => 'id',
+			),
+			$apikey,
+			'GET'
+		);
+
+		if ( 'ok' !== $result['status'] ) {
+			return false;
+		}
+
+		$results = isset( $result['data']['results'] ) ? $result['data']['results'] : array();
+		if ( ! empty( $results[0]['id'] ) ) {
+			return (int) $results[0]['id'];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Extracts the search value from merge_vars for the given update-by strategy.
+	 *
+	 * @param array  $merge_vars Array of mapped form field values.
+	 * @param string $update_by  Strategy key: 'email', 'phone', or 'tax_id'.
+	 * @return string The value to search by, or empty string if not found.
+	 */
+	private function extract_update_by_value( $merge_vars, $update_by ) {
+		$field_map = array(
+			'email'  => 'email',
+			'phone'  => 'phone',
+			'tax_id' => 'taxpayer_identification_number',
+		);
+
+		if ( ! isset( $field_map[ $update_by ] ) ) {
+			return '';
+		}
+
+		$target = $field_map[ $update_by ];
+		foreach ( $merge_vars as $element ) {
+			if ( isset( $element['name'] ) && $target === $element['name'] && ! empty( $element['value'] ) ) {
+				return (string) $element['value'];
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Creates an entry for given module of a CRM
 	 *
 	 * @param  array $settings settings from Gravity Forms options.
@@ -811,9 +885,25 @@ class CRMLIB_Clientify {
 			$contact['tags'] = array_values( array_filter( $contact_tags ) );
 		}
 
-		$result = $this->request( $module . '/', $contact, $apikey );
+		$update_by   = isset( $settings['fc_crm_update_by'] ) ? $settings['fc_crm_update_by'] : 'none';
+		$http_method = 'POST';
+		$endpoint    = $module . '/';
+		$found_id    = false;
+
+		if ( 'none' !== $update_by ) {
+			$search_value = $this->extract_update_by_value( $merge_vars, $update_by );
+			if ( ! empty( $search_value ) ) {
+				$found_id = $this->search_contact( $module, $update_by, $search_value, $apikey );
+				if ( $found_id ) {
+					$http_method = 'PATCH';
+					$endpoint    = $module . '/' . $found_id . '/';
+				}
+			}
+		}
+
+		$result = $this->request( $endpoint, $contact, $apikey, $http_method );
 		if ( 'ok' === $result['status'] ) {
-			$contact_id      = isset( $result['data']['id'] ) ? $result['data']['id'] : '';
+			$contact_id      = isset( $result['data']['id'] ) ? $result['data']['id'] : ( $found_id ? $found_id : '' );
 			$response_result = array(
 				'status'  => 'ok',
 				'message' => 'success',

--- a/includes/crm-library/class-crmlib-clientify.php
+++ b/includes/crm-library/class-crmlib-clientify.php
@@ -19,133 +19,13 @@
 class CRMLIB_Clientify {
  // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Legacy class name, changing would break compatibility.
 
-	/**
-	 * Clientify API v2 base URL.
-	 *
-	 * @var string
-	 */
-	private $api_url = 'https://api-plus.clientify.com/v2/';
 
-	/**
-	 * Gets information from Clientify CRM
-	 *
-	 * @param string $url    URL for module.
-	 * @param string $apikey API Authentication.
-	 *
-	 * @return array
-	 */
-	private function get( $url, $apikey ) {
-		if ( ! $apikey ) {
-			return array(
-				'status' => 'error',
-				'data'   => 'No API Key',
-			);
-		}
-		$args = array(
-			'headers' => array(
-				'Authorization' => 'Token ' . $apikey,
-			),
-			'timeout' => 120,
-		);
-
-		$next          = true;
-		$results_value = array();
-		$url           = $this->api_url . $url;
-
-		while ( $next ) {
-			$result_api  = wp_remote_get( $url, $args );
-			$body_raw    = wp_remote_retrieve_body( $result_api );
-			$results     = json_decode( $body_raw, true );
-			$code_status = (int) wp_remote_retrieve_response_code( $result_api );
-			$code        = (int) round( $code_status / 100, 0 );
-
-			if ( 2 !== $code ) {
-				$message = $code_status . ' ';
-				$body    = json_decode( $body_raw, true );
-
-				if ( is_array( $body ) ) {
-					foreach ( $body as $key => $value ) {
-						$message_value = is_array( $value ) ? implode( '.', $value ) : $value;
-						$message      .= $key . ': ' . $message_value;
-					}
-				}
-				formscrm_error_admin_message( 'ERROR', $message );
-				return array(
-					'status' => 'error',
-					'data'   => $message,
-				);
-			} elseif ( isset( $results['results'] ) ) {
-				$results_value = array_merge( $results_value, $results['results'] );
-			}
-
-			if ( isset( $results['next'] ) && $results['next'] ) {
-				$url = $results['next'];
-			} else {
-				$next = false;
-			}
-		}
-
-		$results['results'] = $results_value;
-		return array(
-			'status' => 'ok',
-			'data'   => $results,
-		);
-	}
-
-	/**
-	 * Sends a request to Clientify API.
-	 *
-	 * @param string $module   URL for module.
-	 * @param array  $bodypost Params to send to API.
-	 * @param string $apikey   API Authentication.
-	 * @param string $method   HTTP method to use.
-	 * @return array
-	 */
-	private function request( $module, $bodypost, $apikey, $method = 'POST' ) {
-		$url  = $this->api_url . strtolower( $module );
-		$args = array(
-			'headers' => array(
-				'Authorization' => 'Token ' . $apikey,
-				'Content-Type'  => 'application/json',
-			),
-			'method'  => $method,
-			'timeout' => 120,
-			'body'    => wp_json_encode( $bodypost ),
-		);
-
-		$result   = wp_remote_request( $url, $args );
-		$body_raw = wp_remote_retrieve_body( $result );
-		$code     = (int) round( (int) wp_remote_retrieve_response_code( $result ) / 100, 0 );
-
-		if ( 2 !== $code ) {
-			$message = wp_remote_retrieve_response_code( $result ) . ' ';
-			$body    = json_decode( $body_raw, true );
-			if ( is_array( $body ) ) {
-				foreach ( $body as $key => $value ) {
-					$message_value = is_array( $value ) ? implode( '.', $value ) : $value;
-					$message      .= $key . ': ' . $message_value;
-				}
-			}
-			formscrm_error_admin_message( 'ERROR', $message );
-			return array(
-				'status' => 'error',
-				'data'   => $message,
-				'url'    => $url,
-				'query'  => wp_json_encode( $bodypost ),
-			);
-		} else {
-			return array(
-				'status' => 'ok',
-				'data'   => json_decode( $body_raw, true ),
-			);
-		}
-	}
 
 	/**
 	 * Logins to a CRM
 	 *
 	 * @param  array $settings settings from Gravity Forms options.
-	 * @return false or id     returns false if cannot login and string if gets token
+	 * @return bool  True if login succeeded, false otherwise.
 	 */
 	public function login( $settings ) {
 		$apikey = isset( $settings['fc_crm_apipassword'] ) ? $settings['fc_crm_apipassword'] : '';
@@ -153,22 +33,12 @@ class CRMLIB_Clientify {
 			return false;
 		}
 
-		$args = array(
-			'headers' => array(
-				'Authorization' => 'Token ' . $apikey,
-			),
-			'timeout' => 120,
-		);
-
-		$result      = wp_remote_get( $this->api_url . 'me/', $args );
-		$body        = json_decode( wp_remote_retrieve_body( $result ), true );
-		$code_status = (int) wp_remote_retrieve_response_code( $result );
-
-		if ( 200 === $code_status && ! empty( $body['id'] ) ) {
-			return true;
+		$result = $this->request( 'me/', array(), $apikey, 'GET' );
+		if ( 'ok' !== $result['status'] || empty( $result['data']['id'] ) ) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 
 	/**
@@ -813,7 +683,7 @@ class CRMLIB_Clientify {
 
 		if ( isset( $object_types_map[ $module_slug ] ) ) {
 			foreach ( $object_types_map[ $module_slug ] as $object_type ) {
-				$result_api = $this->get( 'custom-fields/?object_type=' . $object_type, $apikey );
+				$result_api = $this->request( 'custom-fields/?object_type=' . $object_type, array(), $apikey, 'GET' );
 				if ( isset( $result_api['status'] ) && 'ok' === $result_api['status'] && isset( $result_api['data']['results'] ) ) {
 					foreach ( $result_api['data']['results'] as $custom_field ) {
 						$key  = 'deals' === $object_type ? 'deal|' : '';
@@ -1034,7 +904,7 @@ class CRMLIB_Clientify {
 		$deal_total    = 0;
 		foreach ( $skus as $sku ) {
 			$sku         = trim( $sku );
-			$res_product = $this->get( 'products/?sku=' . $sku, $apikey );
+			$res_product = $this->request( 'products/?sku=' . $sku, array(), $apikey, 'GET' );
 			if ( 'ok' === $res_product['status'] && isset( $res_product['data']['results'][0]['id'] ) ) {
 				$product       = $res_product['data']['results'][0];
 				$product_price = ! empty( $product['price'] ) ? (float) $product['price'] : 0;
@@ -1053,4 +923,105 @@ class CRMLIB_Clientify {
 			'total'  => $deal_total,
 		);
 	}
-} //from Class
+
+	/**
+	 * Sends a request to Clientify API (GET with optional pagination, POST, PUT, etc.).
+	 *
+	 * @param string $module URL path for the API endpoint (e.g. 'me/', 'contacts/').
+	 * @param array  $params Params to send. In GET requests, are fields.
+	 * @param string $apikey API authentication token.
+	 * @param string $method HTTP method: GET, POST, PUT, etc.
+	 * @return array           'status' => 'ok'|'error', 'data' => response or error message.
+	 */
+	private function request( $module, $params = array(), $apikey = '', $method = 'POST' ) {
+		if ( ! $apikey ) {
+			return array(
+				'status' => 'error',
+				'data'   => 'No API Key',
+			);
+		}
+
+		$api_url = 'https://api-plus.clientify.com/v2/';
+		$url     = $api_url . strtolower( $module );
+		$args    = array(
+			'headers' => array(
+				'Authorization' => 'Token ' . $apikey,
+			),
+			'method'  => $method,
+			'timeout' => 120,
+		);
+
+		if ( 'GET' !== $method && ! empty( $params ) ) {
+			$args['headers']['Content-Type'] = 'application/json';
+			$args['body']                    = wp_json_encode( $params );
+		}
+
+		if ( 'GET' === $method ) {
+			if ( empty( $params ) ) {
+				$params = array( 'fields' => 'id' );
+			}
+			$url .= '?' . http_build_query( $params );
+		}
+
+		$next          = true;
+		$results_value = array();
+
+		while ( $next ) {
+			$result   = wp_remote_request( $url, $args );
+			$body_raw = wp_remote_retrieve_body( $result );
+			$results  = json_decode( $body_raw, true );
+			$code     = (int) round( (int) wp_remote_retrieve_response_code( $result ) / 100, 0 );
+
+			if ( 2 !== $code ) {
+				$message = $this->request_error_message( $result, $body_raw );
+				formscrm_error_admin_message( 'ERROR', $message );
+				$out = array(
+					'status' => 'error',
+					'data'   => $message,
+				);
+				if ( 'GET' !== $method ) {
+					$out['url']   = $url;
+					$out['query'] = wp_json_encode( $params );
+				}
+				return $out;
+			}
+
+			if ( 'GET' === $method && isset( $results['results'] ) ) {
+				$results_value = array_merge( $results_value, $results['results'] );
+			}
+
+			if ( 'GET' === $method && ! empty( $results['next'] ) ) {
+				$url = $results['next'];
+			} else {
+				$next = false;
+				if ( 'GET' === $method && ! empty( $results_value ) ) {
+					$results['results'] = $results_value;
+				}
+			}
+		}
+
+		return array(
+			'status' => 'ok',
+			'data'   => 'GET' === $method ? $results : json_decode( $body_raw, true ),
+		);
+	}
+
+	/**
+	 * Builds error message string from API response.
+	 *
+	 * @param array|\WP_Error $result   wp_remote_* result.
+	 * @param string          $body_raw Raw response body.
+	 * @return string
+	 */
+	private function request_error_message( $result, $body_raw ) {
+		$message = (int) wp_remote_retrieve_response_code( $result ) . ' ';
+		$body    = json_decode( $body_raw, true );
+		if ( is_array( $body ) ) {
+			foreach ( $body as $key => $value ) {
+				$message_value = is_array( $value ) ? implode( '.', $value ) : $value;
+				$message      .= $key . ': ' . $message_value;
+			}
+		}
+		return $message;
+	}
+}

--- a/includes/crm-library/class-crmlib-mailerlite.php
+++ b/includes/crm-library/class-crmlib-mailerlite.php
@@ -85,7 +85,8 @@ class CRMLIB_Mailerlite {
 		$api_data    = json_decode( $body, true );
 
 		if ( is_wp_error( $result ) || 200 !== $result_code ) {
-			$message = 'Error: ' . $result->get_error_message() . ' ';
+			$message  = __( 'Error: ', 'formscrm' );
+			$message .= $api_data['error']['message'] ?? __( 'Unknown error', 'formscrm' ) . ' ';
 			if ( ! empty( $api_data['error'] ) && is_array( $api_data['error'] ) ) {
 				foreach ( $api_data['error'] as $key => $value ) {
 					$message .= $key . ': ' . $value . ' ';

--- a/includes/formscrm-library/class-contactform7.php
+++ b/includes/formscrm-library/class-contactform7.php
@@ -165,6 +165,15 @@ class FORMSCRM_CF7_Settings {
 						</span>
 					</p>
 					<p>
+						<label for="wpcf7-crm-fc_crm_update_by"><?php esc_html_e( 'Contact Update Strategy:', 'formscrm' ); ?></label><br />
+						<select name="wpcf7-crm[fc_crm_update_by]" id="wpcf7-crm-fc_crm_update_by" class="medium">
+							<?php foreach ( formscrm_get_update_by_choices() as $choice ) { ?>
+								<option value="<?php echo esc_attr( $choice['value'] ); ?>" <?php selected( isset( $cf7_crm['fc_crm_update_by'] ) ? $cf7_crm['fc_crm_update_by'] : 'none', $choice['value'] ); ?>><?php echo esc_html( $choice['label'] ); ?></option>
+							<?php } ?>
+						</select>
+						<span class="description"><?php esc_html_e( 'Search for an existing contact before creating. If found, it will be updated instead.', 'formscrm' ); ?></span>
+					</p>
+					<p>
 						<label for="wpcf7-crm-fc_crm_mode_expert"><?php esc_html_e( 'Expert Mode', 'formscrm' ); ?></label><br />
 						<input type="checkbox" id="wpcf7-crm-fc_crm_mode_expert" name="wpcf7-crm[fc_crm_mode_expert]" class="medium" value="on" <?php checked( $cf7_crm['fc_crm_mode_expert'], 'on' ); ?> /><?php esc_html_e( 'Enable this option to show all fields of the CRM.', 'formscrm' ); ?>
 					</p>

--- a/includes/formscrm-library/class-elementor.php
+++ b/includes/formscrm-library/class-elementor.php
@@ -171,6 +171,23 @@ class FormsCRM_Elementor_Action_After_Submit extends \ElementorPro\Modules\Forms
 			)
 		);
 
+		// Contact Update Strategy.
+		$update_by_options = array();
+		foreach ( formscrm_get_update_by_choices() as $choice ) {
+			$update_by_options[ $choice['value'] ] = $choice['label'];
+		}
+		$widget->add_control(
+			'fc_crm_update_by',
+			array(
+				'label'       => __( 'Contact Update Strategy', 'formscrm' ),
+				'type'        => \Elementor\Controls_Manager::SELECT,
+				'label_block' => true,
+				'description' => __( 'Search for an existing contact before creating. If found, it will be updated instead.', 'formscrm' ),
+				'options'     => $update_by_options,
+				'default'     => 'none',
+			)
+		);
+
 		// Expert Mode.
 		$widget->add_control(
 			'fc_crm_mode_expert',

--- a/includes/formscrm-library/class-gravityforms-widget.php
+++ b/includes/formscrm-library/class-gravityforms-widget.php
@@ -116,6 +116,9 @@ class FormsCRM_GravityForms_Widget {
 
 		// Check if action was triggered.
 		$resend_action = isset( $_POST['formscrm_action'] ) ? sanitize_text_field( wp_unslash( $_POST['formscrm_action'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified below.
+		if ( empty( $resend_action ) && isset( $args['mode'] ) && ( 'view' === $args['mode'] || 'edit' === $args['mode'] ) ) {
+			$resend_action = 'formscrm_process_feeds_view_edit';
+		}
 
 		if ( $action === $resend_action ) {
 			// Verify nonce for security.

--- a/includes/formscrm-library/class-gravityforms.php
+++ b/includes/formscrm-library/class-gravityforms.php
@@ -576,6 +576,23 @@ class GFCRM extends GFFeedAddOn {
 				);
 			}
 
+			$update_by_choices = array();
+			foreach ( formscrm_get_update_by_choices() as $choice ) {
+				$update_by_choices[] = array(
+					'label' => $choice['label'],
+					'value' => $choice['value'],
+				);
+			}
+			$crm_feed_fields[] = array(
+				'name'       => 'fc_crm_update_by',
+				'label'      => __( 'Contact Update Strategy', 'formscrm' ),
+				'type'       => 'select',
+				'class'      => 'medium',
+				'dependency' => 'fc_crm_module',
+				'tooltip'    => '<h6>' . __( 'Contact Update Strategy', 'formscrm' ) . '</h6>' . __( 'Choose whether to search for an existing contact before creating a new one. If a match is found, the record will be updated instead.', 'formscrm' ),
+				'choices'    => $update_by_choices,
+			);
+
 			$crm_feed_fields[] = array(
 				'name'       => 'listFields',
 				'label'      => __( 'Map Fields', 'formscrm' ),

--- a/includes/formscrm-library/class-woocommerce.php
+++ b/includes/formscrm-library/class-woocommerce.php
@@ -189,6 +189,18 @@ class FormsCRM_WooCommerce {
 			);
 		}
 
+		$options_update_by = array();
+		foreach ( formscrm_get_update_by_choices() as $choice ) {
+			$options_update_by[ $choice['value'] ] = $choice['label'];
+		}
+		$settings_crm[] = array(
+			'name'    => __( 'Contact Update Strategy', 'formscrm' ),
+			'type'    => 'select',
+			'desc'    => __( 'Search for an existing contact before creating. If found, it will be updated instead.', 'formscrm' ),
+			'options' => $options_update_by,
+			'id'      => 'wc_formscrm[fc_crm_update_by]',
+		);
+
 		$settings_crm[] = array(
 			'type' => 'sectionend',
 			'id'   => 'wc_settings_formscrm_section_end',

--- a/includes/formscrm-library/class-wpforms.php
+++ b/includes/formscrm-library/class-wpforms.php
@@ -68,13 +68,14 @@ class FormsCRM_WPForms extends WPForms_Provider {
 
 		// Fire for each connection.
 		foreach ( $form_data['providers'][ $this->slug ] as $connection ) {
-			$account_id                = $connection['account_id'];
-			$settings                  = $this->api_connect( $account_id );
-			$settings['fc_crm_module'] = $connection['list_id'];
-			$merge_vars                = array();
-			$entry_meta                = wpforms()->get( 'entry_meta' );
-			$form_id                   = (int) $form_data['id'];
-			$title                     = '<strong>FormsCRM Log</strong><br/>';
+			$account_id                   = $connection['account_id'];
+			$settings                     = $this->api_connect( $account_id );
+			$settings['fc_crm_module']    = $connection['list_id'];
+			$settings['fc_crm_update_by'] = isset( $connection['fc_crm_update_by'] ) ? $connection['fc_crm_update_by'] : 'none';
+			$merge_vars                   = array();
+			$entry_meta                   = wpforms()->get( 'entry_meta' );
+			$form_id                      = (int) $form_data['id'];
+			$title                        = '<strong>FormsCRM Log</strong><br/>';
 
 			// Check for credentials.
 			if ( empty( $settings['fc_crm_type'] ) ) {
@@ -543,6 +544,19 @@ class FormsCRM_WPForms extends WPForms_Provider {
 				}
 
 				$html .= '</div>';
+				$html .= '</div>';
+
+				// Contact Update Strategy select.
+				$saved_update_by = isset( $connection['fc_crm_update_by'] ) ? $connection['fc_crm_update_by'] : 'none';
+				$html           .= '<div style="margin: 10px 0;">';
+				$html           .= '<label for="wpforms-provider-formscrm-update-by-' . esc_attr( $connection_id ) . '" style="display:block; font-weight:600; margin-bottom:5px;">' . esc_html__( 'Contact Update Strategy', 'formscrm' ) . '</label>';
+				$html           .= '<select id="wpforms-provider-formscrm-update-by-' . esc_attr( $connection_id ) . '" name="providers[' . esc_attr( $this->slug ) . '][' . esc_attr( $connection_id ) . '][fc_crm_update_by]">';
+				foreach ( formscrm_get_update_by_choices() as $choice ) {
+					$selected = selected( $saved_update_by, $choice['value'], false );
+					$html    .= '<option value="' . esc_attr( $choice['value'] ) . '"' . $selected . '>' . esc_html( $choice['label'] ) . '</option>';
+				}
+				$html .= '</select>';
+				$html .= '<p style="margin: 5px 0 0; color: #666; font-size: 12px;">' . esc_html__( 'Search for an existing contact before creating. If found, it will be updated instead.', 'formscrm' ) . '</p>';
 				$html .= '</div>';
 			}
 		}

--- a/includes/formscrm-library/helpers-library-crm.php
+++ b/includes/formscrm-library/helpers-library-crm.php
@@ -170,6 +170,34 @@ if ( ! function_exists( 'formscrm_get_dependency_odoodb' ) ) {
 	}
 }
 
+if ( ! function_exists( 'formscrm_get_update_by_choices' ) ) {
+	/**
+	 * Returns the choices for the update-by contact strategy setting.
+	 *
+	 * @return array
+	 */
+	function formscrm_get_update_by_choices() {
+		return array(
+			array(
+				'value' => 'none',
+				'label' => __( 'Always create new', 'formscrm' ),
+			),
+			array(
+				'value' => 'email',
+				'label' => __( 'Update by Email', 'formscrm' ),
+			),
+			array(
+				'value' => 'phone',
+				'label' => __( 'Update by Phone', 'formscrm' ),
+			),
+			array(
+				'value' => 'tax_id',
+				'label' => __( 'Update by Tax ID', 'formscrm' ),
+			),
+		);
+	}
+}
+
 // Visitor Key.
 add_action( 'init', 'formscrm_visitorkey_session', 1 );
 if ( ! function_exists( 'formscrm_visitorkey_session' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: gravityforms, wpforms, crm, vtiger, odoo
 Donate link: https://close.marketing/go/donate/
 Requires at least: 5.5
 Tested up to: 6.9
-Stable tag: 4.3.1
-Version: 4.3.1
+Stable tag: 4.4.0
+Version: 4.4.0
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -213,14 +213,20 @@ Each Markdown file includes:
 * Integrate with static site generators (Jekyll, Hugo, etc.)
 
 == Settings for Clientify ==
+**Important: API v2 Migration**
+Since version 4.4.0, FormsCRM uses the Clientify API v2 (api-plus.clientify.com). Your existing API key will continue to work without changes. The migration is fully backward compatible with existing feed configurations.
+
 **Instructions for adding Clientify cookie in the forms**
 Clientify cookie adds the ability to merge the contact with the Clientify cookie in the form. You will see if Clientify is added as CRM, a new hidden field in your form. You could check if is already in the form, but if you don't have it you can add it and put as css *clientify_cookie* .
 
-**Add Pipeline name in Opportunities**
-You can add a new field that fits with the Pipeline name in Opportunities in Clientify. You will need to use the same name as the Pipeline in Clientify.
+**Add Pipeline name or ID in Opportunities**
+You can add a new field that fits with the Pipeline name (pipeline_desc) or Pipeline ID (pipeline_id) in Opportunities in Clientify. You can also specify the Pipeline Stage Name (pipeline_stage_desc). You will need to use the same name or ID as the Pipeline in Clientify.
 
 **Add expected closure date for Deals in Clientify**
 You can add a new field that fits with expected closure date for Deals in Clientify. This field is optional, and you need to add a number of days to the expected closure date. The plugin will calculate the date from today and will add it to the Deal in Clientify.
+
+**Marketing Status in Clientify**
+You can set the marketing status for contacts using the marketing_status field. Use value 1 for Sales Contact or value 2 for Marketing Contact.
 
 **Autoassignment in Clientify**
 Field that applies the autoassignment to the contact. You can add a string with the list of usernames (property emails) separated by comma (,) to apply the autoassignment.
@@ -237,6 +243,19 @@ WordPress installation and then activate the Plugin from Plugins page.
 [Official Repository GitHub](https://github.com/closemarketing/formscrm/)
 
 == Changelog ==
+
+= 4.4.0 =
+*  Migrated: Clientify integration from API v1 to API v2 (new base URL: api-plus.clientify.com/v2).
+*  Migrated: Login endpoint from settings/my-account/ to me/.
+*  Migrated: Custom fields endpoint now uses object_type filter for better performance.
+*  Migrated: Deal creation uses ID-based references (contact_id, company_id) instead of URL-based references.
+*  Migrated: Deal products included inline in deal creation payload (v2 schema with product_id and price).
+*  Added: New field marketing_status for Clientify contacts (1=Sales Contact, 2=Marketing Contact).
+*  Added: Pipeline ID and Pipeline Stage Name fields for Clientify deals.
+*  Added: Email Main (type 4) and Phone Main (type 1) field types for Clientify contacts.
+*  Fixed: HTTP PUT requests now use wp_remote_request() instead of wp_remote_post() for correct method support.
+*  Fixed: Error response body access now consistently uses wp_remote_retrieve_body().
+*  Fixed: Pipeline field mapping (pipeline_desc) now maps correctly to the API field.
 
 = 4.3.1 =
 *  Fixed: File upload field not sending correctly in GravityForms.

--- a/readme.txt
+++ b/readme.txt
@@ -245,17 +245,10 @@ WordPress installation and then activate the Plugin from Plugins page.
 == Changelog ==
 
 = 4.4.0 =
-*  Migrated: Clientify integration from API v1 to API v2 (new base URL: api-plus.clientify.com/v2).
-*  Migrated: Login endpoint from settings/my-account/ to me/.
-*  Migrated: Custom fields endpoint now uses object_type filter for better performance.
-*  Migrated: Deal creation uses ID-based references (contact_id, company_id) instead of URL-based references.
-*  Migrated: Deal products included inline in deal creation payload (v2 schema with product_id and price).
-*  Added: New field marketing_status for Clientify contacts (1=Sales Contact, 2=Marketing Contact).
-*  Added: Pipeline ID and Pipeline Stage Name fields for Clientify deals.
-*  Added: Email Main (type 4) and Phone Main (type 1) field types for Clientify contacts.
-*  Fixed: HTTP PUT requests now use wp_remote_request() instead of wp_remote_post() for correct method support.
-*  Fixed: Error response body access now consistently uses wp_remote_retrieve_body().
-*  Fixed: Pipeline field mapping (pipeline_desc) now maps correctly to the API field.
+*  Migrated: Clientify to API v2 (api-plus.clientify.com/v2): login me/, custom fields object_type filter, deal creation with ID-based refs and inline products (v2 schema).
+*  Added: Clientify contact marketing_status, pipeline ID/stage name, and Email Main/Phone Main field types.
+*  Fixed: HTTP PUT via wp_remote_request(), consistent wp_remote_retrieve_body() for errors, pipeline_desc mapping.
+*  Fixed: GravityForms widget sending leads twice when viewing or editing an entry.
 
 = 4.3.1 =
 *  Fixed: File upload field not sending correctly in GravityForms.

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: gravityforms, wpforms, crm, vtiger, odoo
 Donate link: https://close.marketing/go/donate/
 Requires at least: 5.5
 Tested up to: 6.9
-Stable tag: 4.4.0
-Version: 4.4.0
+Stable tag: 4.3.2
+Version: 4.3.2
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -244,7 +244,7 @@ WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
 
-= 4.4.0 =
+= 4.3.2 =
 *  Migrated: Clientify to API v2 (api-plus.clientify.com/v2): login me/, custom fields object_type filter, deal creation with ID-based refs and inline products (v2 schema).
 *  Added: Clientify contact marketing_status, pipeline ID/stage name, and Email Main/Phone Main field types.
 *  Fixed: HTTP PUT via wp_remote_request(), consistent wp_remote_retrieve_body() for errors, pipeline_desc mapping.

--- a/tests/API/test-clientify.php
+++ b/tests/API/test-clientify.php
@@ -64,6 +64,115 @@ class ClientifyTests extends WP_UnitTestCase {
 			$response_file = 'clientify-custom-fields.json';
 		}
 
+		// V2 contact search by email: existing contact.
+		if ( str_contains( $url, '/v2/contacts/' ) && 'GET' === $r['method'] && str_contains( $url, 'email=existing' ) ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'count'   => 1,
+						'next'    => null,
+						'results' => array(
+							array( 'id' => 99999 ),
+						),
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}
+
+		// V2 contact/company search by tax_id: existing record.
+		if ( str_contains( $url, '/v2/contacts/' ) && 'GET' === $r['method'] && str_contains( $url, 'taxpayer_identification_number' ) ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'count'   => 1,
+						'next'    => null,
+						'results' => array(
+							array( 'id' => 99999 ),
+						),
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}
+
+		// V2 company search by email: existing company.
+		if ( str_contains( $url, '/v2/companies/' ) && 'GET' === $r['method'] && str_contains( $url, 'email=existing' ) ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'count'   => 1,
+						'next'    => null,
+						'results' => array(
+							array( 'id' => 88888 ),
+						),
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}
+
+		// V2 contact/company search: no match.
+		if ( ( str_contains( $url, '/v2/contacts/' ) || str_contains( $url, '/v2/companies/' ) ) && 'GET' === $r['method'] ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'count'   => 0,
+						'next'    => null,
+						'results' => array(),
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}
+
+		// V2 contact update via PATCH.
+		if ( str_contains( $url, '/v2/contacts/' ) && 'PATCH' === $r['method'] ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'id'         => 99999,
+						'first_name' => 'Test',
+						'last_name'  => 'User',
+						'email'      => 'existing@example.com',
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}
+
+		// V2 company update via PATCH.
+		if ( str_contains( $url, '/v2/companies/' ) && 'PATCH' === $r['method'] ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'id'    => 88888,
+						'name'  => 'Existing Company',
+						'email' => 'existing@company.com',
+					)
+				),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+			);
+		}
+
 		// V2 contact creation.
 		if ( str_contains( $url, '/v2/contacts/' ) && 'POST' === $r['method'] ) {
 			return array(
@@ -74,6 +183,22 @@ class ClientifyTests extends WP_UnitTestCase {
 						'last_name'  => 'User',
 						'email'      => 'test@example.com',
 						'status'     => 'cold-lead',
+					)
+				),
+				'response' => array(
+					'code'    => 201,
+					'message' => 'Created',
+				),
+			);
+		}
+
+		// V2 company creation.
+		if ( str_contains( $url, '/v2/companies/' ) && 'POST' === $r['method'] ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'id'   => 200001,
+						'name' => 'New Company',
 					)
 				),
 				'response' => array(
@@ -260,5 +385,134 @@ class ClientifyTests extends WP_UnitTestCase {
 		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
 		$this->assertEquals( 'ok', $result['status'] );
 		$this->assertEquals( 'deal', $result['module'] );
+	}
+
+	/**
+	 * Test update_by = 'none': always creates new contact via POST.
+	 */
+	public function test_create_entry_update_by_none_always_creates() {
+		$this->settings['fc_crm_update_by'] = 'none';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'Test',
+			),
+			array(
+				'name'  => 'email',
+				'value' => 'test@example.com',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 100597402, $result['id'] );
+	}
+
+	/**
+	 * Test update_by = 'email': updates existing contact via PATCH when match found.
+	 */
+	public function test_create_entry_update_by_email_found() {
+		$this->settings['fc_crm_update_by'] = 'email';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'Test',
+			),
+			array(
+				'name'  => 'email',
+				'value' => 'existing@example.com',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 99999, $result['id'] );
+	}
+
+	/**
+	 * Test update_by = 'email': creates new contact via POST when no match found.
+	 */
+	public function test_create_entry_update_by_email_not_found() {
+		$this->settings['fc_crm_update_by'] = 'email';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'New',
+			),
+			array(
+				'name'  => 'email',
+				'value' => 'new@example.com',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 100597402, $result['id'] );
+	}
+
+	/**
+	 * Test update_by = 'email': creates new contact when email field is missing.
+	 */
+	public function test_create_entry_update_by_email_empty_value() {
+		$this->settings['fc_crm_update_by'] = 'email';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'Test',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 100597402, $result['id'] );
+	}
+
+	/**
+	 * Test update_by = 'tax_id': updates existing contact via PATCH when match found.
+	 */
+	public function test_create_entry_update_by_tax_id_found() {
+		$this->settings['fc_crm_update_by'] = 'tax_id';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'Test',
+			),
+			array(
+				'name'  => 'taxpayer_identification_number',
+				'value' => '12345678A',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 99999, $result['id'] );
+	}
+
+	/**
+	 * Test update_by = 'email' on companies module: updates existing company via PATCH.
+	 */
+	public function test_create_entry_update_by_email_companies_found() {
+		$this->settings['fc_crm_module']     = 'Companies';
+		$this->settings['fc_crm_update_by']  = 'email';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'name',
+				'value' => 'Existing Company',
+			),
+			array(
+				'name'  => 'email',
+				'value' => 'existing@company.com',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 88888, $result['id'] );
 	}
 }

--- a/tests/API/test-clientify.php
+++ b/tests/API/test-clientify.php
@@ -1,100 +1,264 @@
 <?php
 /**
  * Class ClientifyTests
- * 
+ *
+ * Tests for Clientify API v2 integration.
  * Command: composer test-debug --filter ClientifyTests
  *
  * @package Formscrm
  */
 
 /**
- * Sample test case.
+ * Clientify API v2 test case.
  */
 class ClientifyTests extends WP_UnitTestCase {
 
 	/**
 	 * Settings for testing
+	 *
+	 * @var array
 	 */
 	protected $settings;
-	
+
 	/**
 	 * API connection for testing
+	 *
+	 * @var CRMLIB_Clientify
 	 */
 	protected $crm_clientify;
-	
+
 	/**
 	 * Set up test environment.
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		
-		$this->settings = [
-			'fc_crm_type' => 'clientify',
+
+		$this->settings = array(
+			'fc_crm_type'        => 'clientify',
 			'fc_crm_apipassword' => 'api-password',
-			'fc_crm_module' => 'Contacts',
-		];
+			'fc_crm_module'      => 'Contacts',
+		);
 		$this->crm_clientify = formscrm_get_api_class( 'clientify' );
-		
-		// Mock the HTTP request to return a successful response.
-		add_filter(
-			'pre_http_request',
-			function( $pre, $r, $url ) {
-				$body_query    = ! empty( $r['body'] ) ? json_decode( $r['body'], true ) : array();
-				$response_file = 'clientify-';
 
-				// Login.
-				if ( str_contains( $url, 'settings/my-account/' ) ) {
-					$response_file .= 'login.json';
-				}
-				if ( str_contains( $url, 'custom-fields/' ) ) {
-					$response_file .= 'custom-fields.json';
-				}
-
-				$response_file = UNIT_TESTS_DATA_PLUGIN_DIR . $response_file;
-				if ( file_exists( $response_file ) ) {
-					return array(
-						'body' => file_get_contents( $response_file ),
-						'response' => array( 'code' => 200, 'message' => 'OK' ),
-					);
-				}
-
-				return array(
-					'body' => '',
-					'response' => array( 'code' => 500, 'message' => 'Error API' ),
-				);
-			},
-		10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'mock_http_requests' ), 10, 3 );
 	}
 
+	/**
+	 * Mock HTTP requests for Clientify API v2.
+	 *
+	 * @param false|array $pre     Pre-emptive return value.
+	 * @param array       $r       Request arguments.
+	 * @param string      $url     Request URL.
+	 * @return array Mocked response.
+	 */
+	public function mock_http_requests( $pre, $r, $url ) {
+		$response_file = '';
+
+		// V2 login endpoint.
+		if ( str_contains( $url, '/v2/me/' ) ) {
+			$response_file = 'clientify-login.json';
+		}
+
+		// V2 custom fields endpoint.
+		if ( str_contains( $url, '/v2/custom-fields/' ) ) {
+			$response_file = 'clientify-custom-fields.json';
+		}
+
+		// V2 contact creation.
+		if ( str_contains( $url, '/v2/contacts/' ) && 'POST' === $r['method'] ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'id'         => 100597402,
+						'first_name' => 'Test',
+						'last_name'  => 'User',
+						'email'      => 'test@example.com',
+						'status'     => 'cold-lead',
+					)
+				),
+				'response' => array(
+					'code'    => 201,
+					'message' => 'Created',
+				),
+			);
+		}
+
+		// V2 deal creation.
+		if ( str_contains( $url, '/v2/deals/' ) && 'POST' === $r['method'] ) {
+			return array(
+				'body'     => wp_json_encode(
+					array(
+						'id'     => 626,
+						'name'   => 'Test Deal',
+						'amount' => '1000.00',
+					)
+				),
+				'response' => array(
+					'code'    => 201,
+					'message' => 'Created',
+				),
+			);
+		}
+
+		if ( $response_file ) {
+			$response_file = UNIT_TESTS_DATA_PLUGIN_DIR . $response_file;
+			if ( file_exists( $response_file ) ) {
+				return array(
+					'body'     => file_get_contents( $response_file ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+				);
+			}
+		}
+
+		return array(
+			'body'     => '',
+			'response' => array(
+				'code'    => 500,
+				'message' => 'Error API',
+			),
+		);
+	}
+
+	/**
+	 * Test login succeeds with valid credentials.
+	 */
 	public function test_login_without_errors() {
 		$login = $this->crm_clientify->login( $this->settings );
 		$this->assertTrue( $login );
 	}
 
+	/**
+	 * Test login fails with empty API key.
+	 */
 	public function test_login_with_errors() {
 		$this->settings['fc_crm_apipassword'] = '';
 		$login = $this->crm_clientify->login( $this->settings );
 		$this->assertFalse( $login );
 	}
 
+	/**
+	 * Test modules list returns expected structure.
+	 */
 	public function test_list_modules_without_errors() {
 		$modules = $this->crm_clientify->list_modules( $this->settings );
-		$this->assertTrue( is_array( $modules ) );
+		$this->assertIsArray( $modules );
+		$module_names = array_column( $modules, 'name' );
+		$this->assertContains( 'contacts', $module_names );
+		$this->assertContains( 'contacts-deals', $module_names );
+		$this->assertContains( 'companies', $module_names );
+		$this->assertContains( 'companies-deals', $module_names );
 	}
 
+	/**
+	 * Test fields list returns standard and custom fields.
+	 */
 	public function test_list_fields_without_errors() {
 		$fields = $this->crm_clientify->list_fields( $this->settings, 'Contacts' );
-		$this->assertTrue( is_array( $fields ) );
-		$fields = array_column( $fields, 'name' );
-		$this->assertTrue( in_array( 'first_name', $fields ) );
-		$this->assertTrue( in_array( 'last_name', $fields ) );
-		$this->assertTrue( in_array( 'email', $fields ) );
-		$this->assertTrue( in_array( 'phone', $fields ) );
-		$this->assertTrue( in_array( 'company', $fields ) );
-		$this->assertTrue( in_array( 'custom_fields|interes2', $fields ) );
-		$this->assertTrue( in_array( 'websites|corporate', $fields ) );
-		$this->assertTrue( in_array( 'websites|personal', $fields ) );
-		$this->assertTrue( in_array( 'custom_fields|verified', $fields ) );
-		$this->assertTrue( in_array( 'custom_fields|social_lead_1', $fields ) );
+		$this->assertIsArray( $fields );
+		$field_names = array_column( $fields, 'name' );
+
+		// Standard fields.
+		$this->assertContains( 'first_name', $field_names );
+		$this->assertContains( 'last_name', $field_names );
+		$this->assertContains( 'email', $field_names );
+		$this->assertContains( 'phone', $field_names );
+		$this->assertContains( 'company', $field_names );
+
+		// Website fields.
+		$this->assertContains( 'websites|corporate', $field_names );
+		$this->assertContains( 'websites|personal', $field_names );
+
+		// Custom fields from v2 mock data.
+		$this->assertContains( 'custom_fields|interes2', $field_names );
+		$this->assertContains( 'custom_fields|verified', $field_names );
+		$this->assertContains( 'custom_fields|social_lead_1', $field_names );
+	}
+
+	/**
+	 * Test v2 email type 4 (Main) and phone type 1 (Main) are present.
+	 */
+	public function test_list_fields_includes_v2_types() {
+		$fields      = $this->crm_clientify->list_fields( $this->settings, 'Contacts' );
+		$field_names = array_column( $fields, 'name' );
+
+		$this->assertContains( 'emails|4', $field_names );
+		$this->assertContains( 'phones|1', $field_names );
+	}
+
+	/**
+	 * Test deal fields are present for contacts-deals module.
+	 */
+	public function test_list_fields_deals_module() {
+		$fields      = $this->crm_clientify->list_fields( $this->settings, 'contacts-deals' );
+		$field_names = array_column( $fields, 'name' );
+
+		$this->assertContains( 'deal|name', $field_names );
+		$this->assertContains( 'deal|amount', $field_names );
+		$this->assertContains( 'deal|pipeline_desc', $field_names );
+		$this->assertContains( 'deal|pipeline_id', $field_names );
+		$this->assertContains( 'deal|pipeline_stage_desc', $field_names );
+		$this->assertContains( 'deal|product_skus', $field_names );
+		$this->assertContains( 'deal|tags', $field_names );
+	}
+
+	/**
+	 * Test creating a contact entry.
+	 */
+	public function test_create_entry_contact() {
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'Test',
+			),
+			array(
+				'name'  => 'last_name',
+				'value' => 'User',
+			),
+			array(
+				'name'  => 'email',
+				'value' => 'test@example.com',
+			),
+			array(
+				'name'  => 'status',
+				'value' => 'cold-lead',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 100597402, $result['id'] );
+	}
+
+	/**
+	 * Test creating a contact with deal entry.
+	 */
+	public function test_create_entry_contact_deal() {
+		$this->settings['fc_crm_module'] = 'contacts-deals';
+
+		$merge_vars = array(
+			array(
+				'name'  => 'first_name',
+				'value' => 'Test',
+			),
+			array(
+				'name'  => 'email',
+				'value' => 'test@example.com',
+			),
+			array(
+				'name'  => 'deal|name',
+				'value' => 'Test Deal',
+			),
+			array(
+				'name'  => 'deal|amount',
+				'value' => '1000',
+			),
+		);
+
+		$result = $this->crm_clientify->create_entry( $this->settings, $merge_vars );
+		$this->assertEquals( 'ok', $result['status'] );
+		$this->assertEquals( 'deal', $result['module'] );
 	}
 }

--- a/tests/Data/clientify-custom-fields.json
+++ b/tests/Data/clientify-custom-fields.json
@@ -1,396 +1,62 @@
 {
-	"count": 354,
+	"count": 5,
 	"next": null,
 	"previous": null,
 	"results": [
 		{
-			"url": "https://api.clientify.net/v1/custom-fields/476966/",
 			"id": 476966,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
 			"name": "verified",
 			"help_text": "",
 			"field_type": 3,
 			"field_type_display": "Text",
 			"default_value": "",
 			"dropdown_choices": [],
-			"visible": false
+			"visible": false,
+			"object_type": "contacts"
 		},
 		{
-			"url": "https://api.clientify.net/v1/custom-fields/476965/",
 			"id": 476965,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
 			"name": "social_lead_1",
 			"help_text": "",
 			"field_type": 3,
 			"field_type_display": "Text",
 			"default_value": "",
 			"dropdown_choices": [],
-			"visible": false
+			"visible": false,
+			"object_type": "contacts"
 		},
 		{
-			"url": "https://api.clientify.net/v1/custom-fields/476964/",
-			"id": 476964,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "social_lead",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476963/",
-			"id": 476963,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "satisfaccion_atencion_al_cliente",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476962/",
-			"id": 476962,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "quiero_comprar",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476961/",
-			"id": 476961,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "para_su_1er_inversin_cuenta_con",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476960/",
-			"id": 476960,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "nmero_de_telfono",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476959/",
-			"id": 476959,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "item",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476958/",
-			"id": 476958,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "interes_categoria",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476957/",
 			"id": 476957,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
 			"name": "interes2",
 			"help_text": "",
 			"field_type": 3,
 			"field_type_display": "Text",
 			"default_value": "",
 			"dropdown_choices": [],
-			"visible": false
+			"visible": false,
+			"object_type": "contacts"
 		},
 		{
-			"url": "https://api.clientify.net/v1/custom-fields/476956/",
 			"id": 476956,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
 			"name": "info_chat",
 			"help_text": "",
 			"field_type": 3,
 			"field_type_display": "Text",
 			"default_value": "",
 			"dropdown_choices": [],
-			"visible": false
+			"visible": false,
+			"object_type": "contacts"
 		},
 		{
-			"url": "https://api.clientify.net/v1/custom-fields/476955/",
-			"id": 476955,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "have_you_or_a_loved_one_been_injured_in_an_accident",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476954/",
-			"id": 476954,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "formulario_satisfaccion_de_atencion_al_cliente",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476953/",
-			"id": 476953,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "estado_del_contacto",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476952/",
-			"id": 476952,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "en_una_escala_del_1_al_5___cuanto_satisfecho_esta_usted_con_nuestro_producto_servicio_",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476951/",
-			"id": 476951,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "documento",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476950/",
 			"id": 476950,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
 			"name": "datos_de_contacto",
 			"help_text": "",
 			"field_type": 3,
 			"field_type_display": "Text",
 			"default_value": "",
 			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476949/",
-			"id": 476949,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "cuentas_con_la_inversin_de_1000000",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476948/",
-			"id": 476948,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "correo_electrnico",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476947/",
-			"id": 476947,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "comentarios",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476946/",
-			"id": 476946,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "ciudad",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/476923/",
-			"id": 476923,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "carrito_abandonado",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/473103/",
-			"id": 473103,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "products | product",
-			"name": "unidad_medida_alegra",
-			"help_text": "",
-			"field_type": 1,
-			"field_type_display": "Dropdown",
-			"default_value": "",
-			"dropdown_choices": [
-				{
-					"name": "unit"
-				},
-				{
-					"name": "centimeter"
-				},
-				{
-					"name": "meter"
-				},
-				{
-					"name": "inch"
-				},
-				{
-					"name": "centimeterSquared"
-				},
-				{
-					"name": "meterSquared"
-				},
-				{
-					"name": "inchSquared"
-				},
-				{
-					"name": "mililiter"
-				},
-				{
-					"name": "liter"
-				},
-				{
-					"name": "gallon"
-				},
-				{
-					"name": "gram"
-				},
-				{
-					"name": "kilogram"
-				},
-				{
-					"name": "service"
-				},
-				{
-					"name": "par"
-				},
-				{
-					"name": "cubicMeterNet"
-				},
-				{
-					"name": "cubicMeter"
-				},
-				{
-					"name": "hour"
-				},
-				{
-					"name": "MIN"
-				},
-				{
-					"name": "DAY"
-				},
-				{
-					"name": "box"
-				},
-				{
-					"name": "drum"
-				}
-			],
-			"visible": true
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/473102/",
-			"id": 473102,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "products | product",
-			"name": "prueba producto custom field",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
-		},
-		{
-			"url": "https://api.clientify.net/v1/custom-fields/472950/",
-			"id": 472950,
-			"user_company": "PRUEBA CLOSE",
-			"content_type": "contacts | contact",
-			"name": "zoom_webinar_registration_count",
-			"help_text": "",
-			"field_type": 3,
-			"field_type_display": "Text",
-			"default_value": "",
-			"dropdown_choices": [],
-			"visible": false
+			"visible": false,
+			"object_type": "contacts"
 		}
 	]
 }

--- a/tests/Data/clientify-login.json
+++ b/tests/Data/clientify-login.json
@@ -1,18 +1,25 @@
 {
-	"count": 1,
-	"next": null,
-	"previous": null,
-	"results": [
-			{
-					"language": "es",
-					"country": "ES",
-					"time_zone": "Europe/Madrid",
-					"currency": "EUR",
-					"currency_symbol": "€",
-					"currency_format": 1,
-					"hour_format": 1,
-					"date_format": 1,
-					"sub_brand": ""
-			}
-	]
+	"id": 83428,
+	"username": "desarrollo@clientify.com",
+	"last_name": "Zaraki",
+	"company": "PRUEBA CLOSE",
+	"permissions_profile": "Administrador",
+	"permissions_profile_id": 1008,
+	"is_tester": false,
+	"is_partner_admin": false,
+	"inbox_user": true,
+	"sales_user": true,
+	"language": "es",
+	"full_name": "Kenpachi Zaraki",
+	"role": "nivel 1",
+	"role_id": 1518,
+	"is_company_admin": true,
+	"company_id": 14800,
+	"is_partner": false,
+	"picture": "",
+	"sales_status": 2,
+	"inbox_status": 2,
+	"have_marketing_active": true,
+	"have_communication_active": true,
+	"have_sales_active": true
 }

--- a/tests/Data/clientify-login.json
+++ b/tests/Data/clientify-login.json
@@ -1,25 +1,3 @@
 {
-	"id": 83428,
-	"username": "desarrollo@clientify.com",
-	"last_name": "Zaraki",
-	"company": "PRUEBA CLOSE",
-	"permissions_profile": "Administrador",
-	"permissions_profile_id": 1008,
-	"is_tester": false,
-	"is_partner_admin": false,
-	"inbox_user": true,
-	"sales_user": true,
-	"language": "es",
-	"full_name": "Kenpachi Zaraki",
-	"role": "nivel 1",
-	"role_id": 1518,
-	"is_company_admin": true,
-	"company_id": 14800,
-	"is_partner": false,
-	"picture": "",
-	"sales_status": 2,
-	"inbox_status": 2,
-	"have_marketing_active": true,
-	"have_communication_active": true,
-	"have_sales_active": true
+	"id": 57672
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,11 @@ if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
 	exit( 1 );
 }
 
+// Point the test lib bootstrap to the config file in the tests dir (needed when includes/ is symlinked).
+if ( file_exists( "{$_tests_dir}/wp-tests-config.php" ) ) {
+	define( 'WP_TESTS_CONFIG_FILE_PATH', "{$_tests_dir}/wp-tests-config.php" );
+}
+
 // Give access to tests_add_filter() function.
 require_once "{$_tests_dir}/includes/functions.php";
 

--- a/tests/clientify.php
+++ b/tests/clientify.php
@@ -1,6 +1,7 @@
 <?php
-/** 
- * API DOCS: https://developer.clientify.com/
+/**
+ * API DOCS: https://newapi.clientify.com/
+ * API v2 Base URL: https://api-plus.clientify.com/v2/
  * TEST: http://formscrm.local/wp-content/plugins/formscrm/tests/clientify.php
  */
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a "Contact Update Strategy" option for Clientify forms to prevent duplicate records.

This PR introduces a feed-level setting (`fc_crm_update_by`) across all form integrations, allowing users to configure whether to search for and update an existing Clientify contact or company by Tax ID, Email, or Phone before creating a new one. This is built on top of the Clientify API v2 migration.

---
<p><a href="https://cursor.com/agents/bc-582e1a55-7ff7-46b9-b0e7-4aa7541f6b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-582e1a55-7ff7-46b9-b0e7-4aa7541f6b20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->