### PR TITLE
Fix WPForms CRM select output escaping

### DIFF
--- a/includes/formscrm-library/class-wpforms.php
+++ b/includes/formscrm-library/class-wpforms.php
@@ -564,16 +564,16 @@ class FormsCRM_WPForms extends WPForms_Provider {
 		$options_crm  = formscrm_get_choices();
 		$option_saved = '';
 		foreach ( $options_crm as $option_crm ) {
-			$select_page .= '<option value="' . $option_crm['value'] . '"';
+			$select_page .= '<option value="' . esc_attr( $option_crm['value'] ) . '"';
 			if ( $option_saved === $option_crm['value'] ) {
 				$select_page .= ' selected';
 			}
-			$select_page .= '>' . $option_crm['label'] . '</option>';
+			$select_page .= '>' . esc_html( $option_crm['label'] ) . '</option>';
 		}
 
 		printf(
 			'<select id="fc_crm_type" name="fc_crm_type">%s</select>',
-			wp_kses_post( $select_page )
+			$select_page // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		);
 
 		// CRM URL.

--- a/readme.txt
+++ b/readme.txt
@@ -238,6 +238,9 @@ WordPress installation and then activate the Plugin from Plugins page.
 
 == Changelog ==
 
+= 4.3.2 =
+*  Fixed: WPForms > Connections was not working correctly.
+
 = 4.3.1 =
 *  Enhanced: Support for GravityPDF merge tags in GravityForms.
 *  Fixed: File upload field not sending correctly in GravityForms.


### PR DESCRIPTION
Fixes improper HTML escaping in the WPForms CRM selector dropdown. The `wp_kses_post()` function was being used to escape already-escaped `<option>` HTML, which was stripping valid `value` attributes and causing the select to render incorrectly.

## Changes

- Escape `<option>` `value` attribute with `esc_attr()` instead of leaving it unescaped
- Escape `<option>` label text with `esc_html()` instead of leaving it unescaped
- Replace `wp_kses_post()` on the final `printf()` output (which was incorrectly stripping properly-built HTML) with a direct output + `phpcs:ignore` comment, since individual values are already escaped at construction time

## Benefits

- The CRM type selector in WPForms now renders correctly with all options visible
- Output follows WordPress security best practices: each piece of data is escaped at the point of output with the correct escaping function
- No false positives from `wp_kses_post()` stripping valid attribute content

## Testing Instructions

1. Install and activate WPForms and FormsCRM
2. Go to **WPForms → All Forms** and edit any form
3. Navigate to the **Marketing** tab in the form builder
4. Click **Add New Connection** for FormsCRM
5. Verify the **CRM Type** dropdown renders all available CRM options correctly
6. Select a CRM option and confirm the value is saved properly

## Checklist

- [x] Code follows WordPress Coding Standards
- [x] Self-reviewed the code
- [x] Added necessary comments (`phpcs:ignore` with justification)
- [x] No new linter errors