### PR TITLE
Fix GDPR checkbox handling for unchecked state in CF7 forms

### DIFF
--- a/includes/formscrm-library/class-contactform7.php
+++ b/includes/formscrm-library/class-contactform7.php
@@ -322,7 +322,7 @@ class FORMSCRM_CF7_Settings {
 			}
 			$crm_key = str_replace( 'fc_crm_field-', '', $key );
 
-			if ( ! empty( $submitted_data[ $value ] ) ) {
+			if ( isset( $submitted_data[ $value ] ) ) {
 				$value = $submitted_data[ $value ];
 			}
 

--- a/tests/Forms/test-contactform.php
+++ b/tests/Forms/test-contactform.php
@@ -46,4 +46,48 @@ class ContactFormsTest extends WP_UnitTestCase {
 			array( 'name' => 'custom_fields|info_chat', 'value' => 'Autónomo' ),
 		) );
 	}
+
+	/**
+	 * GDPR checkbox unchecked: CF7 submits empty array, value must be '' not the field name.
+	 */
+	public function test_get_merge_vars_gdpr_unchecked() {
+		$cf7_crm = array(
+			'fc_crm_type'              => 'clientify',
+			'fc_crm_apipassword'       => 'api-password',
+			'fc_crm_module'            => 'Contacts',
+			'fc_crm_field-gdpr_accept' => 'extra-info',
+		);
+
+		$submitted_data = array(
+			'extra-info' => array(), // Unchecked checkbox returns empty array in CF7.
+		);
+
+		$merge_vars = $this->contact_form->get_merge_vars( $cf7_crm, $submitted_data );
+		$this->assertEquals(
+			array( array( 'name' => 'gdpr_accept', 'value' => '' ) ),
+			$merge_vars
+		);
+	}
+
+	/**
+	 * GDPR checkbox checked: CF7 submits the label string, value must be non-empty.
+	 */
+	public function test_get_merge_vars_gdpr_checked() {
+		$cf7_crm = array(
+			'fc_crm_type'              => 'clientify',
+			'fc_crm_apipassword'       => 'api-password',
+			'fc_crm_module'            => 'Contacts',
+			'fc_crm_field-gdpr_accept' => 'extra-info',
+		);
+
+		$submitted_data = array(
+			'extra-info' => array( 'Me gustaría estar al tanto de las novedades de Ipace' ),
+		);
+
+		$merge_vars = $this->contact_form->get_merge_vars( $cf7_crm, $submitted_data );
+		$this->assertEquals(
+			array( array( 'name' => 'gdpr_accept', 'value' => 'Me gustaría estar al tanto de las novedades de Ipace' ) ),
+			$merge_vars
+		);
+	}
 }


### PR DESCRIPTION
## Summary
Fixed a bug in the Contact Form 7 integration where unchecked GDPR checkboxes were not being properly handled when submitting data to the CRM. The issue was that empty arrays (submitted by CF7 for unchecked checkboxes) were being treated as falsy values, preventing the field from being included in the merge variables.

## Key Changes
- Changed the condition in `get_merge_vars()` from `! empty()` to `isset()` to properly handle empty arrays submitted by CF7 for unchecked checkboxes
- Added test case `test_get_merge_vars_gdpr_unchecked()` to verify that unchecked GDPR checkboxes result in an empty string value
- Added test case `test_get_merge_vars_gdpr_checked()` to verify that checked GDPR checkboxes properly pass through the label text

## Implementation Details
The fix distinguishes between:
- **Unchecked checkbox**: CF7 submits an empty array `[]`, which should map to an empty string `''` in the CRM field
- **Checked checkbox**: CF7 submits an array with the label string, which should be passed through as-is

By using `isset()` instead of `! empty()`, the code now correctly processes both states, ensuring GDPR consent fields are always included in the CRM submission with the appropriate value.

https://claude.ai/code/session_01L5SX14n8w68mnppe99jPDg