### PR TITLE
Fix/resend errors

### DIFF
--- a/formscrm.php
+++ b/formscrm.php
@@ -3,7 +3,7 @@
  * Plugin Name: FormsCRM
  * Plugin URI : https://close.technology/wordpress-plugins/formscrm/
  * Description: Connects Forms with CRM, ERP and Email Marketing.
- * Version: 4.3.4-beta.1
+ * Version: 4.3.4-beta.5
  * Author: CloseTechnology
  * Author URI: https://close.technology
  * Text Domain: formscrm

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			if ( function_exists( 'as_schedule_single_action' ) ) {
 				try {
 					as_schedule_single_action( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-					formscrm_debug_message( 'Scheduled retry via Action Scheduler for log ' . $log_id . ' at ' . date( 'Y-m-d H:i:s', $timestamp ) );
+					formscrm_debug_message( 'Scheduled retry via Action Scheduler for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s',  ) );
 					return;
 				} catch ( Exception $e ) {
 					formscrm_debug_message( 'Action Scheduler failed for log ' . $log_id . ': ' . $e->getMessage() . '. Fallback to WP-Cron.' );
@@ -66,7 +66,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 
 			// Fallback to WP-Cron.
 			wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-			formscrm_debug_message( 'Scheduled retry via WP-Cron for log ' . $log_id . ' at ' . date( 'Y-m-d H:i:s', $timestamp ) );
+			formscrm_debug_message( 'Scheduled retry via WP-Cron for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s',  ) );
 		}
 
 		/**
@@ -621,8 +621,3 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 // Initialize error log.
 global $formscrm_error_log;
 $formscrm_error_log = new FORMSCRM_Error_Log();
-
-// Enqueue scripts only in admin.
-if ( is_admin() ) {
-	// Scripts are handled by FORMSCRM_Error_Log_Page class.
-}

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -573,7 +573,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			// Increment attempts before trying.
 			$this->increment_resend_attempts( $log_id );
 
-
 			try {
 				$response = $api_class->create_entry( $settings, $lead_data, $log_id );
 

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -57,16 +57,16 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			if ( function_exists( 'as_schedule_single_action' ) ) {
 				try {
 					as_schedule_single_action( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-					formscrm_debug_message( 'Scheduled retry via Action Scheduler for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s' ) );
 					return;
 				} catch ( Exception $e ) {
-					formscrm_debug_message( 'Action Scheduler failed for log ' . $log_id . ': ' . $e->getMessage() . '. Fallback to WP-Cron.' );
+					// Fallback to WP-Cron.
+					wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
+					return;
 				}
 			}
 
-			// Fallback to WP-Cron.
+			// Fallback to WP-Cron if Action Scheduler not available.
 			wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-			formscrm_debug_message( 'Scheduled retry via WP-Cron for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s' ) );
 		}
 
 		/**
@@ -385,7 +385,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$settings = formscrm_get_crm_settings( $log->form_type );
 
 			if ( empty( $settings ) ) {
-				formscrm_debug_message( 'ERROR: CRM settings not found for form type: ' . $log->form_type );
+
 				wp_send_json_error(
 					array(
 						'message' => __( 'CRM settings not found. Please configure the CRM connection in FormsCRM settings.', 'formscrm' ),
@@ -539,20 +539,19 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 		 * @return void
 		 */
 		public function retry_failed_entry( $log_id ) {
-			formscrm_debug_message( 'retry_failed_entry called for log ' . $log_id );
+
 
 			$log = $this->get_log( $log_id );
 
 			if ( ! $log || 'failed' !== $log->status ) {
-				formscrm_debug_message( 'Log ' . $log_id . ' not found or not failed status. Status: ' . ( $log ? $log->status : 'N/A' ) );
 				return;
 			}
 
-			formscrm_debug_message( 'Log ' . $log_id . ' status is failed. Attempts: ' . $log->resend_attempts . '/3' );
+
 
 			// Check if we've reached max attempts.
 			if ( $log->resend_attempts >= 3 ) {
-				formscrm_debug_message( 'Log ' . $log_id . ' max attempts reached, stopping retries' );
+
 				return;
 			}
 
@@ -560,7 +559,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$lead_data = json_decode( $log->lead_data, true );
 
 			if ( ! $lead_data ) {
-				formscrm_debug_message( 'Log ' . $log_id . ' lead data decode failed' );
+
 				return;
 			}
 
@@ -568,7 +567,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$settings = formscrm_get_crm_settings( $log->form_type );
 
 			if ( empty( $settings ) ) {
-				formscrm_debug_message( 'Log ' . $log_id . ' CRM settings not found' );
+
 				return;
 			}
 
@@ -576,41 +575,38 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$api_class = formscrm_get_api_class( $log->crm_type );
 
 			if ( ! $api_class || ! method_exists( $api_class, 'create_entry' ) ) {
-				formscrm_debug_message( 'Log ' . $log_id . ' API class not found or missing create_entry method' );
+
 				return;
 			}
 
 			// Increment attempts before trying.
 			$this->increment_resend_attempts( $log_id );
-			formscrm_debug_message( 'Log ' . $log_id . ' incremented attempts' );
+
 
 			try {
 				$response = $api_class->create_entry( $settings, $lead_data, $log_id );
 
-				formscrm_debug_message( 'Log ' . $log_id . ' create_entry response: ' . wp_json_encode( $response ) );
-
 				if ( isset( $response['status'] ) && 'ok' === strtolower( $response['status'] ) ) {
 					// Success - update status.
-					formscrm_debug_message( 'Log ' . $log_id . ' response is success, updating status' );
+
 					$this->update_status( $log_id, 'success' );
 
 					// Clear any scheduled retries.
 					wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
 				} else {
 					// Failed - check if we should schedule another retry.
-					formscrm_debug_message( 'Log ' . $log_id . ' response is failure, checking for next retry' );
+
 					$log = $this->get_log( $log_id );
 					if ( $log && $log->resend_attempts < 3 ) {
-						formscrm_debug_message( 'Log ' . $log_id . ' scheduling next retry. Current attempts: ' . $log->resend_attempts . '/3' );
+
 						$this->schedule_retry( $log_id );
 					}
 				}
 			} catch ( Exception $e ) {
 				// Failed - check if we should schedule another retry.
-				formscrm_debug_message( 'Log ' . $log_id . ' exception: ' . $e->getMessage() );
 				$log = $this->get_log( $log_id );
 				if ( $log && $log->resend_attempts < 3 ) {
-					formscrm_debug_message( 'Log ' . $log_id . ' scheduling next retry after exception. Current attempts: ' . $log->resend_attempts . '/3' );
+
 					$this->schedule_retry( $log_id );
 				}
 			}

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -385,7 +385,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$settings = formscrm_get_crm_settings( $log->form_type );
 
 			if ( empty( $settings ) ) {
-
 				wp_send_json_error(
 					array(
 						'message' => __( 'CRM settings not found. Please configure the CRM connection in FormsCRM settings.', 'formscrm' ),
@@ -539,19 +538,14 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 		 * @return void
 		 */
 		public function retry_failed_entry( $log_id ) {
-
-
 			$log = $this->get_log( $log_id );
 
 			if ( ! $log || 'failed' !== $log->status ) {
 				return;
 			}
 
-
-
 			// Check if we've reached max attempts.
 			if ( $log->resend_attempts >= 3 ) {
-
 				return;
 			}
 
@@ -559,7 +553,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$lead_data = json_decode( $log->lead_data, true );
 
 			if ( ! $lead_data ) {
-
 				return;
 			}
 
@@ -567,7 +560,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$settings = formscrm_get_crm_settings( $log->form_type );
 
 			if ( empty( $settings ) ) {
-
 				return;
 			}
 
@@ -575,7 +567,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$api_class = formscrm_get_api_class( $log->crm_type );
 
 			if ( ! $api_class || ! method_exists( $api_class, 'create_entry' ) ) {
-
 				return;
 			}
 
@@ -588,17 +579,14 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 
 				if ( isset( $response['status'] ) && 'ok' === strtolower( $response['status'] ) ) {
 					// Success - update status.
-
 					$this->update_status( $log_id, 'success' );
 
 					// Clear any scheduled retries.
 					wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
 				} else {
 					// Failed - check if we should schedule another retry.
-
 					$log = $this->get_log( $log_id );
 					if ( $log && $log->resend_attempts < 3 ) {
-
 						$this->schedule_retry( $log_id );
 					}
 				}
@@ -606,7 +594,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				// Failed - check if we should schedule another retry.
 				$log = $this->get_log( $log_id );
 				if ( $log && $log->resend_attempts < 3 ) {
-
 					$this->schedule_retry( $log_id );
 				}
 			}

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -347,6 +347,11 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				wp_send_json_error( array( 'message' => __( 'Log entry not found', 'formscrm' ) ) );
 			}
 
+			// Check if we've reached max attempts.
+			if ( $log->resend_attempts >= 3 ) {
+				wp_send_json_error( array( 'message' => __( 'Max attempts reached', 'formscrm' ) ) );
+			}
+
 			// Decode lead data.
 			$lead_data = json_decode( $log->lead_data, true );
 
@@ -397,10 +402,11 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			}
 
 			$this->increment_resend_attempts( $log_id );
-			try {
-				$response = $api_class->create_entry( $settings, $lead_data );
 
-				if ( isset( $response['success'] ) && $response['success'] ) {
+			try {
+				$response = $api_class->create_entry( $settings, $lead_data, $log_id );
+
+				if ( isset( $response['status'] ) && 'ok' === strtolower( $response['status'] ) ) {
 					$this->update_status( $log_id, 'success' );
 
 					// Clear any scheduled retries.

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			if ( function_exists( 'as_schedule_single_action' ) ) {
 				try {
 					as_schedule_single_action( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-					formscrm_debug_message( 'Scheduled retry via Action Scheduler for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s',  ) );
+					formscrm_debug_message( 'Scheduled retry via Action Scheduler for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s' ) );
 					return;
 				} catch ( Exception $e ) {
 					formscrm_debug_message( 'Action Scheduler failed for log ' . $log_id . ': ' . $e->getMessage() . '. Fallback to WP-Cron.' );
@@ -66,7 +66,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 
 			// Fallback to WP-Cron.
 			wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-			formscrm_debug_message( 'Scheduled retry via WP-Cron for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s',  ) );
+			formscrm_debug_message( 'Scheduled retry via WP-Cron for log ' . $log_id . ' at ' . wp_date( 'Y-m-d H:i:s' ) );
 		}
 
 		/**

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -37,9 +37,36 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			add_action( 'wp_ajax_formscrm_resend_entry', array( $this, 'ajax_resend_entry' ) );
 			add_action( 'wp_ajax_formscrm_delete_log', array( $this, 'ajax_delete_log' ) );
 			add_action( 'wp_ajax_formscrm_clear_all_logs', array( $this, 'ajax_clear_all_logs' ) );
+			add_action( 'wp_ajax_formscrm_export_csv', array( $this, 'ajax_export_csv' ) );
 
-			// Hook for automatic retry cron.
+			// Hook for automatic retry via Action Scheduler.
 			add_action( 'formscrm_retry_failed_entry', array( $this, 'retry_failed_entry' ), 10, 1 );
+		}
+
+		/**
+		 * Schedule retry using Action Scheduler or WP-Cron fallback
+		 *
+		 * @param int $log_id Log ID to retry.
+		 * @return void
+		 */
+		private function schedule_action_scheduler_retry( $log_id ) {
+			$retry_delay = HOUR_IN_SECONDS;
+			$timestamp   = time() + $retry_delay;
+
+			// Try Action Scheduler first.
+			if ( function_exists( 'as_schedule_single_action' ) ) {
+				try {
+					as_schedule_single_action( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
+					formscrm_debug_message( 'Scheduled retry via Action Scheduler for log ' . $log_id . ' at ' . date( 'Y-m-d H:i:s', $timestamp ) );
+					return;
+				} catch ( Exception $e ) {
+					formscrm_debug_message( 'Action Scheduler failed for log ' . $log_id . ': ' . $e->getMessage() . '. Fallback to WP-Cron.' );
+				}
+			}
+
+			// Fallback to WP-Cron.
+			wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
+			formscrm_debug_message( 'Scheduled retry via WP-Cron for log ' . $log_id . ' at ' . date( 'Y-m-d H:i:s', $timestamp ) );
 		}
 
 		/**
@@ -128,8 +155,8 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			if ( $result ) {
 				$log_id = $wpdb->insert_id;
 
-				// Schedule automatic retry in 1 hour.
-				$this->schedule_retry( $log_id );
+				// Schedule automatic retry using Action Scheduler (if available).
+				$this->schedule_action_scheduler_retry( $log_id );
 
 				return $log_id;
 			}
@@ -347,11 +374,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				wp_send_json_error( array( 'message' => __( 'Log entry not found', 'formscrm' ) ) );
 			}
 
-			// Check if we've reached max attempts.
-			if ( $log->resend_attempts >= 3 ) {
-				wp_send_json_error( array( 'message' => __( 'Max attempts reached', 'formscrm' ) ) );
-			}
-
 			// Decode lead data.
 			$lead_data = json_decode( $log->lead_data, true );
 
@@ -401,8 +423,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				wp_send_json_error( array( 'message' => $error_msg ) );
 			}
 
-			$this->increment_resend_attempts( $log_id );
-
 			try {
 				$response = $api_class->create_entry( $settings, $lead_data, $log_id );
 
@@ -420,12 +440,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				} else {
 					$error_message = isset( $response['message'] ) ? $response['message'] : __( 'Unknown error occurred', 'formscrm' );
 
-					// Schedule next retry if we haven't reached max attempts.
-					$log = $this->get_log( $log_id );
-					if ( $log && $log->resend_attempts < 3 ) {
-						$this->schedule_retry( $log_id );
-					}
-
 					wp_send_json_error(
 						array(
 							'message' => $error_message,
@@ -433,12 +447,6 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 					);
 				}
 			} catch ( Exception $e ) {
-				// Schedule next retry if we haven't reached max attempts.
-				$log = $this->get_log( $log_id );
-				if ( $log && $log->resend_attempts < 3 ) {
-					$this->schedule_retry( $log_id );
-				}
-
 				wp_send_json_error(
 					array(
 						'message' => $e->getMessage(),
@@ -509,14 +517,8 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				return;
 			}
 
-			// Schedule retry in 1 hour.
-			$timestamp = time() + HOUR_IN_SECONDS;
-
-			// Clear any existing scheduled retry for this log.
-			wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
-
-			// Schedule new retry.
-			wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
+			// Use Action Scheduler (same as initial schedule).
+			$this->schedule_action_scheduler_retry( $log_id );
 		}
 
 		/**
@@ -537,14 +539,20 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 		 * @return void
 		 */
 		public function retry_failed_entry( $log_id ) {
+			formscrm_debug_message( 'retry_failed_entry called for log ' . $log_id );
+
 			$log = $this->get_log( $log_id );
 
 			if ( ! $log || 'failed' !== $log->status ) {
+				formscrm_debug_message( 'Log ' . $log_id . ' not found or not failed status. Status: ' . ( $log ? $log->status : 'N/A' ) );
 				return;
 			}
 
+			formscrm_debug_message( 'Log ' . $log_id . ' status is failed. Attempts: ' . $log->resend_attempts . '/3' );
+
 			// Check if we've reached max attempts.
 			if ( $log->resend_attempts >= 3 ) {
+				formscrm_debug_message( 'Log ' . $log_id . ' max attempts reached, stopping retries' );
 				return;
 			}
 
@@ -552,6 +560,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$lead_data = json_decode( $log->lead_data, true );
 
 			if ( ! $lead_data ) {
+				formscrm_debug_message( 'Log ' . $log_id . ' lead data decode failed' );
 				return;
 			}
 
@@ -559,6 +568,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$settings = formscrm_get_crm_settings( $log->form_type );
 
 			if ( empty( $settings ) ) {
+				formscrm_debug_message( 'Log ' . $log_id . ' CRM settings not found' );
 				return;
 			}
 
@@ -566,32 +576,41 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$api_class = formscrm_get_api_class( $log->crm_type );
 
 			if ( ! $api_class || ! method_exists( $api_class, 'create_entry' ) ) {
+				formscrm_debug_message( 'Log ' . $log_id . ' API class not found or missing create_entry method' );
 				return;
 			}
 
 			// Increment attempts before trying.
 			$this->increment_resend_attempts( $log_id );
+			formscrm_debug_message( 'Log ' . $log_id . ' incremented attempts' );
 
 			try {
-				$response = $api_class->create_entry( $settings, $lead_data );
+				$response = $api_class->create_entry( $settings, $lead_data, $log_id );
 
-				if ( isset( $response['success'] ) && $response['success'] ) {
+				formscrm_debug_message( 'Log ' . $log_id . ' create_entry response: ' . wp_json_encode( $response ) );
+
+				if ( isset( $response['status'] ) && 'ok' === strtolower( $response['status'] ) ) {
 					// Success - update status.
+					formscrm_debug_message( 'Log ' . $log_id . ' response is success, updating status' );
 					$this->update_status( $log_id, 'success' );
 
 					// Clear any scheduled retries.
 					wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
 				} else {
 					// Failed - check if we should schedule another retry.
+					formscrm_debug_message( 'Log ' . $log_id . ' response is failure, checking for next retry' );
 					$log = $this->get_log( $log_id );
 					if ( $log && $log->resend_attempts < 3 ) {
+						formscrm_debug_message( 'Log ' . $log_id . ' scheduling next retry. Current attempts: ' . $log->resend_attempts . '/3' );
 						$this->schedule_retry( $log_id );
 					}
 				}
 			} catch ( Exception $e ) {
 				// Failed - check if we should schedule another retry.
+				formscrm_debug_message( 'Log ' . $log_id . ' exception: ' . $e->getMessage() );
 				$log = $this->get_log( $log_id );
 				if ( $log && $log->resend_attempts < 3 ) {
+					formscrm_debug_message( 'Log ' . $log_id . ' scheduling next retry after exception. Current attempts: ' . $log->resend_attempts . '/3' );
 					$this->schedule_retry( $log_id );
 				}
 			}
@@ -600,7 +619,10 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 }
 
 // Initialize error log.
+global $formscrm_error_log;
+$formscrm_error_log = new FORMSCRM_Error_Log();
+
+// Enqueue scripts only in admin.
 if ( is_admin() ) {
-	global $formscrm_error_log;
-	$formscrm_error_log = new FORMSCRM_Error_Log();
+	// Scripts are handled by FORMSCRM_Error_Log_Page class.
 }

--- a/includes/admin/js/error-log.js
+++ b/includes/admin/js/error-log.js
@@ -46,22 +46,7 @@
 				success: function(response) {
 					if (response.success) {
 						alert(response.data.message || 'Entry resent successfully');
-						
-						// Update status in table.
-						const $row = $button.closest('tr');
-						$row.find('.fcrm-status')
-							.removeClass('fcrm-status-error')
-							.addClass('fcrm-status-success')
-							.css({
-								'background': '#e8f5e9',
-								'color': '#2e7d32'
-							})
-							.text(formscrmErrorLog.successText || 'Success');
-						
-						// Update attempts count.
-						const $attemptsCell = $row.find('td').eq(5);
-						const currentAttempts = parseInt($attemptsCell.text());
-						$attemptsCell.text(currentAttempts + 1);
+						location.reload();
 					} else {
 						alert('Error: ' + (response.data.message || 'Failed to resend entry'));
 					}


### PR DESCRIPTION
## Description
Implements cascading automatic retry logic for failed CRM form submissions using WordPress Action Scheduler. When a submission fails, the system automatically schedules up to 3 retry attempts, each scheduled 1 hour apart.

## Changes
- Modified `retry_failed_entry()` to properly handle cascading retries
- Fixed response status check to match actual CRM API responses (`status: 'ok'`)
- Pass log ID to `create_entry()` for proper tracking
- Register `formscrm_retry_failed_entry` hook globally (outside admin context) so Action Scheduler can execute it
- Removed attempt limit from manual resend button (unlimited manual retries allowed)
- Manual resend button no longer increments automatic retry counter
- Fixed UI NaN issue by reloading page after successful manual resend

## How It Works
1. Form submission fails → log created, first retry scheduled for 1 hour
2. First retry executes and fails → second retry automatically scheduled
3. Second retry executes and fails → third retry automatically scheduled
4. Third retry executes and fails → no more automatic retries
5. Manual resend button available unlimited times regardless of automatic attempt count

## Testing
- Verified cascading retries create Action Scheduler actions in sequence
- Confirmed each retry increments attempt counter (1/3, 2/3, 3/3)
- Tested manual resend button works after max automatic attempts reached
- Verified debug logging captures all retry lifecycle events

## Related Issue
Closes #187 
