### PR TITLE
Fix Brevo list_modules pagination to return all lists

### DIFF
--- a/formscrm.php
+++ b/formscrm.php
@@ -3,7 +3,7 @@
  * Plugin Name: FormsCRM
  * Plugin URI : https://close.technology/wordpress-plugins/formscrm/
  * Description: Connects Forms with CRM, ERP and Email Marketing.
- * Version: 4.3.4-beta.3
+ * Version: 4.3.4-beta.4
  * Author: CloseTechnology
  * Author URI: https://close.technology
  * Text Domain: formscrm

--- a/includes/crm-library/class-crmlib-brevo.php
+++ b/includes/crm-library/class-crmlib-brevo.php
@@ -48,19 +48,21 @@ class CRMLIB_Brevo {
 		}
 
 		if ( 'GET' === $method ) {
-			$limit        = 100; // default limit.
+			$limit        = 50;
 			$offset       = 0;
 			$result_data  = array();
 			$repeat_query = false;
 
-			// . '?limit=' . $limit . '&offset=' . $offset
 			do {
-				$result = $this->request( $module, $args );
+				$paginated_module = $module . '?limit=' . $limit . '&offset=' . $offset;
+				$result           = $this->request( $paginated_module, $args );
 
 				if ( 'ok' === $result['status'] && ! empty( $result['data'] ) && is_array( $result['data'] ) ) {
-					$offset      += count( $result['data'] );
-					$result_data  = array_merge( $result_data, $result['data'] );
-					$repeat_query = count( $result['data'] ) === $limit ? true : false;
+					$items        = isset( $result['data']['lists'] ) ? $result['data']['lists'] : $result['data'];
+					$offset      += count( $items );
+					$result_data  = array_merge( $result_data, $items );
+					$total        = isset( $result['data']['count'] ) ? (int) $result['data']['count'] : 0;
+					$repeat_query = $offset < $total;
 				} else {
 					return $result;
 				}
@@ -121,13 +123,20 @@ class CRMLIB_Brevo {
 				return true;
 			}
 
-			return false;
+			$error_msg = isset( $results['data'] ) ? $results['data'] : __( 'Unable to connect to Brevo API', 'formscrm' );
+			return array(
+				'status'  => 'error',
+				'message' => $error_msg,
+			);
 		} catch ( \Exception $e ) {
 
 			// Log that authentication test failed.
 			error_log( __METHOD__ . '(): API credentials are invalid; ' . $e->getMessage() ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional logging for API errors.
 
-			return false;
+			return array(
+				'status'  => 'error',
+				'message' => __( 'Invalid API credentials', 'formscrm' ),
+			);
 		}
 	}
 
@@ -141,7 +150,8 @@ class CRMLIB_Brevo {
 		$apikey = isset( $settings['fc_crm_apipassword'] ) ? $settings['fc_crm_apipassword'] : '';
 
 		// If API cannot be initialized, return array.
-		if ( ! $this->login( $settings ) ) {
+		$login_check = $this->login( $settings );
+		if ( true !== $login_check ) {
 			return array();
 		}
 
@@ -150,12 +160,12 @@ class CRMLIB_Brevo {
 		$result_lists = $this->api( 'GET', 'contacts/lists', $apikey );
 
 		// If no lists were found, return.
-		if ( 'error' === $result_lists['status'] || empty( $result_lists['data']['lists'] ) ) {
+		if ( 'error' === $result_lists['status'] || empty( $result_lists['data'] ) ) {
 			return array();
 		}
 
 		// Loop through array.
-		foreach ( $result_lists['data']['lists'] as $list ) {
+		foreach ( $result_lists['data'] as $list ) {
 
 			// Add list as choice.
 			$choices[] = array(

--- a/includes/formscrm-library/class-contactform7.php
+++ b/includes/formscrm-library/class-contactform7.php
@@ -133,9 +133,14 @@ class FORMSCRM_CF7_Settings {
 					?>
 					<p>
 						<label for="fc_crm_module"><?php esc_html_e( 'CRM Module:', 'formscrm' ); ?></label><br />
+						<?php
+						$modules = $this->crmlib->list_modules( $cf7_crm );
+						if ( empty( $modules ) ) {
+							echo '<p style="color: red;">' . esc_html__( 'No modules found. Check your API credentials and try reconnecting.', 'formscrm' ) . '</p>';
+						} else {
+							?>
 						<select name="wpcf7-crm[fc_crm_module]" class="medium formscrm-autosubmit" id="fc_crm_module" data-formscrm-autosubmit="true">
 							<?php
-							$modules = $this->crmlib->list_modules( $cf7_crm );
 							foreach ( $modules as $module ) {
 								$value = '';
 								if ( ! empty( $module['value'] ) ) {
@@ -163,6 +168,9 @@ class FORMSCRM_CF7_Settings {
 							<span class="dashicons dashicons-update-alt"></span>
 							<?php esc_html_e( 'Saving...', 'formscrm' ); ?>
 						</span>
+							<?php
+						}
+						?>
 					</p>
 					<p>
 						<label for="wpcf7-crm-fc_crm_mode_expert"><?php esc_html_e( 'Expert Mode', 'formscrm' ); ?></label><br />
@@ -179,14 +187,10 @@ class FORMSCRM_CF7_Settings {
 			if ( ! empty( $this->crmlib ) ) {
 				$login_crm = $this->crmlib->login( $cf7_crm );
 				if ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) {
-					return;
-				}
-
-				if ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) {
 					echo '<p style="color: red;">' . esc_html( $login_crm['message'] ) . '</p>';
 					return;
 				}
-				if ( false === $login_crm ) {
+				if ( true !== $login_crm && false !== $login_crm ) {
 					return;
 				}
 			}

--- a/includes/formscrm-library/class-gravityforms.php
+++ b/includes/formscrm-library/class-gravityforms.php
@@ -554,11 +554,21 @@ class GFCRM extends GFFeedAddOn {
 			return $crm_feed_fields;
 		}
 
-		if ( false === $login_crm ) {
+		if ( true !== $login_crm && false !== $login_crm ) {
 			// Connection status field already added above, no additional fields needed.
 			return $crm_feed_fields;
 		} else {
-			$module = $this->get_actual_feed_value( 'fc_crm_module', $feed_settings );
+			$module          = $this->get_actual_feed_value( 'fc_crm_module', $feed_settings );
+			$modules_choices = $this->crmlib->list_modules( $settings );
+
+			if ( empty( $modules_choices ) ) {
+				$modules_choices = array(
+					array(
+						'label' => esc_html__( 'No modules found. Check your API credentials.', 'formscrm' ),
+						'value' => '',
+					),
+				);
+			}
 
 			$crm_feed_fields[] = array(
 				'name'     => 'fc_crm_module',
@@ -566,7 +576,7 @@ class GFCRM extends GFFeedAddOn {
 				'type'     => 'select',
 				'class'    => 'medium',
 				'onchange' => 'jQuery(this).parents("form").submit();',
-				'choices'  => $this->crmlib->list_modules( $settings ),
+				'choices'  => $modules_choices,
 			);
 			if ( empty( $module ) ) {
 				$crm_feed_fields[] = array(

--- a/includes/formscrm-library/class-woocommerce.php
+++ b/includes/formscrm-library/class-woocommerce.php
@@ -176,8 +176,15 @@ class FormsCRM_WooCommerce {
 			$this->crmlib   = formscrm_get_api_class( $wc_formscrm['fc_crm_type'] );
 			$options_module = array();
 			if ( ! empty( $this->crmlib ) && method_exists( $this->crmlib, 'list_modules' ) ) {
-				foreach ( $this->crmlib->list_modules( $wc_formscrm ) as $module ) {
-					$options_module[ $module['value'] ] = $module['label'];
+				$modules = $this->crmlib->list_modules( $wc_formscrm );
+				if ( empty( $modules ) ) {
+					$options_module = array(
+						'' => esc_html__( 'No modules found. Check your API credentials.', 'formscrm' ),
+					);
+				} else {
+					foreach ( $modules as $module ) {
+						$options_module[ $module['value'] ] = $module['label'];
+					}
 				}
 			}
 			$settings_crm[] = array(

--- a/includes/formscrm-library/elementor-ajax.php
+++ b/includes/formscrm-library/elementor-ajax.php
@@ -98,6 +98,9 @@ function elementor_formscrm_connect_crm() { // phpcs:ignore WordPress.NamingConv
 			<div class="elementor-control-field ">
 				<label for="fc_crm_module" class="elementor-control-title"><?php esc_html_e( 'CRM Module', 'formscrm' ); ?></label>
 				<div class="elementor-control-input-wrapper elementor-control-unit-5">
+					<?php if ( empty( $modules ) ) { ?>
+						<p style="color: red;"><?php esc_html_e( 'No modules found. Check your API credentials and try reconnecting.', 'formscrm' ); ?></p>
+					<?php } else { ?>
 					<select id="fc_crm_module">
 					<?php
 					foreach ( $modules as $module ) {
@@ -120,6 +123,7 @@ function elementor_formscrm_connect_crm() { // phpcs:ignore WordPress.NamingConv
 					}
 					?>
 					</select>
+					<?php } ?>
 				</div>
 			</div>
 			<div class="elementor-control-field-description"></div>

--- a/includes/formscrm-library/elementor-ajax.php
+++ b/includes/formscrm-library/elementor-ajax.php
@@ -102,26 +102,26 @@ function elementor_formscrm_connect_crm() { // phpcs:ignore WordPress.NamingConv
 						<p style="color: red;"><?php esc_html_e( 'No modules found. Check your API credentials and try reconnecting.', 'formscrm' ); ?></p>
 					<?php } else { ?>
 					<select id="fc_crm_module">
-					<?php
-					foreach ( $modules as $module ) {
-						$value = '';
-						if ( ! empty( $module['value'] ) ) {
-							$value = $module['value'];
-						} elseif ( ! empty( $module['name'] ) ) {
-							$value = $module['name'];
-						}
-						if ( empty( $value ) || ! isset( $module['label'] ) ) {
-							continue;
-						}
-						echo '<option value="' . esc_html( $value ) . '" ';
+						<?php
+						foreach ( $modules as $module ) {
+							$value = '';
+							if ( ! empty( $module['value'] ) ) {
+								$value = $module['value'];
+							} elseif ( ! empty( $module['name'] ) ) {
+								$value = $module['name'];
+							}
+							if ( empty( $value ) || ! isset( $module['label'] ) ) {
+								continue;
+							}
+							echo '<option value="' . esc_html( $value ) . '" ';
 
-						if ( $value ) {
-							selected( $settings_module, $value );
-						}
+							if ( $value ) {
+								selected( $settings_module, $value );
+							}
 
-						echo '>' . esc_html( $module['label'] ) . '</option>';
-					}
-					?>
+							echo '>' . esc_html( $module['label'] ) . '</option>';
+						}
+						?>
 					</select>
 					<?php } ?>
 				</div>

--- a/readme.txt
+++ b/readme.txt
@@ -248,6 +248,7 @@ WordPress installation and then activate the Plugin from Plugins page.
 * Fixed: Elementor not getting correctly the module from settings.
 * Fixed: Normalize boolean CRM fields to standardized values for Clientify.
 * Fixed: CF7 "Saving..." spinner was always visible because wp_kses strips display:none from inline styles; moved visibility control to CSS class.
+* Fixed: Brevo list_modules pagination now returns all lists instead of only 10 by properly sending limit/offset parameters and accumulating paginated results.
 
 = 4.3.3 =
 * Added: Smart support for Clientify API v2 and v1 with enhanced login response handling and error messages. 

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: gravityforms, wpforms, crm, vtiger, odoo
 Donate link: https://close.marketing/go/donate/
 Requires at least: 5.5
 Tested up to: 7.0
-Stable tag: 4.3.3
-Version: 4.3.3
+Stable tag: 4.3.4
+Version: 4.3.4
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/tests/API/test-brevo.php
+++ b/tests/API/test-brevo.php
@@ -1,0 +1,445 @@
+<?php
+/**
+ * Class BrevoTests
+ *
+ * Command: composer test-debug -- --filter BrevoTests
+ *
+ * @package Formscrm
+ */
+
+/**
+ * Brevo API integration tests.
+ */
+class BrevoTests extends WP_UnitTestCase {
+
+	/**
+	 * Settings for testing.
+	 *
+	 * @var array
+	 */
+	protected $settings;
+
+	/**
+	 * API connection for testing.
+	 *
+	 * @var CRMLIB_Brevo
+	 */
+	protected $crm_brevo;
+
+	/**
+	 * Controls which scenario the mock simulates: 'ok', 'error', 'empty'.
+	 *
+	 * @var string
+	 */
+	protected $mock_mode = 'ok';
+
+	/**
+	 * Last body sent to a POST endpoint.
+	 *
+	 * @var array|null
+	 */
+	protected $last_request_body = null;
+
+	/**
+	 * Set up test environment.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->settings = array(
+			'fc_crm_type'        => 'brevo',
+			'fc_crm_apipassword' => 'test-api-key-xxxxx',
+			'fc_crm_module'      => 10,
+		);
+		$this->crm_brevo   = formscrm_get_api_class( 'brevo' );
+		$this->mock_mode   = 'ok';
+		$this->last_request_body = null;
+
+		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Tear down: remove the mock filter.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Central HTTP mock. Behaviour controlled by $this->mock_mode.
+	 *
+	 * @param mixed  $pre Pre-empt value.
+	 * @param array  $r   Request args.
+	 * @param string $url Request URL.
+	 * @return array
+	 */
+	public function mock_http_request( $pre, $r, $url ) {
+		if ( 'error' === $this->mock_mode ) {
+			return $this->response( 401, '{"code":"unauthorized","message":"Key not found"}' );
+		}
+
+		// contacts/lists endpoint (login + list_modules).
+		if ( str_contains( $url, 'contacts/lists' ) ) {
+			if ( 'empty' === $this->mock_mode ) {
+				return $this->response( 200, '{"lists":[],"count":0}' );
+			}
+			return $this->response( 200, file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'brevo-get-contacts-lists.json' ) );
+		}
+
+		// contacts/attributes endpoint (list_fields).
+		if ( str_contains( $url, 'contacts/attributes' ) ) {
+			return $this->response( 200, file_get_contents( UNIT_TESTS_DATA_PLUGIN_DIR . 'brevo-get-contacts-attributes.json' ) );
+		}
+
+		// contacts POST endpoint (create_entry) — capture body for assertions.
+		if ( 'POST' === $r['method'] && str_contains( $url, '/contacts' ) ) {
+			$this->last_request_body = json_decode( $r['body'], true );
+			return $this->response( 201, '{"id":42}' );
+		}
+
+		return $this->response( 500 );
+	}
+
+	/**
+	 * Builds a mock HTTP response array.
+	 *
+	 * @param int    $code HTTP status code.
+	 * @param string $body Response body.
+	 * @return array
+	 */
+	private function response( $code, $body = '' ) {
+		return array(
+			'body'     => $body,
+			'response' => array(
+				'code'    => $code,
+				'message' => 200 === $code || 201 === $code ? 'OK' : 'Error',
+			),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Login tests.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Valid API key returns true.
+	 */
+	public function test_login_valid_credentials_returns_true() {
+		$result = $this->crm_brevo->login( $this->settings );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Invalid API key returns error array.
+	 */
+	public function test_login_invalid_credentials_returns_error() {
+		$this->mock_mode = 'error';
+		$result          = $this->crm_brevo->login( $this->settings );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+	}
+
+	/**
+	 * Empty API key returns null/falsy without making HTTP calls.
+	 */
+	public function test_login_empty_apikey_returns_falsy() {
+		$this->settings['fc_crm_apipassword'] = '';
+		$result = $this->crm_brevo->login( $this->settings );
+		$this->assertNotTrue( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// list_modules tests.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns an array with label/value pairs from the mock data.
+	 */
+	public function test_list_modules_returns_lists() {
+		$modules = $this->crm_brevo->list_modules( $this->settings );
+		$this->assertIsArray( $modules );
+		$this->assertNotEmpty( $modules );
+	}
+
+	/**
+	 * Each module entry has label (string) and value (int).
+	 */
+	public function test_list_modules_entries_have_label_and_int_value() {
+		$modules = $this->crm_brevo->list_modules( $this->settings );
+		foreach ( $modules as $module ) {
+			$this->assertArrayHasKey( 'label', $module );
+			$this->assertArrayHasKey( 'value', $module );
+			$this->assertIsString( $module['label'] );
+			$this->assertIsInt( $module['value'] );
+		}
+	}
+
+	/**
+	 * List IDs from mock data are present in the returned modules.
+	 */
+	public function test_list_modules_contains_expected_ids() {
+		$modules = $this->crm_brevo->list_modules( $this->settings );
+		$values  = array_column( $modules, 'value' );
+		$this->assertContains( 10, $values );
+		$this->assertContains( 15, $values );
+		$this->assertContains( 19, $values );
+	}
+
+	/**
+	 * List names from mock data are present in returned modules.
+	 */
+	public function test_list_modules_contains_expected_names() {
+		$modules = $this->crm_brevo->list_modules( $this->settings );
+		$labels  = array_column( $modules, 'label' );
+		$this->assertContains( 'Test List A', $labels );
+		$this->assertContains( 'Test List J', $labels );
+	}
+
+	/**
+	 * Bad credentials return an empty array.
+	 */
+	public function test_list_modules_on_auth_error_returns_empty_array() {
+		$this->mock_mode = 'error';
+		$modules         = $this->crm_brevo->list_modules( $this->settings );
+		$this->assertIsArray( $modules );
+		$this->assertEmpty( $modules );
+	}
+
+	/**
+	 * Empty lists response returns an empty array.
+	 */
+	public function test_list_modules_on_empty_lists_returns_empty_array() {
+		$this->mock_mode = 'empty';
+		$modules         = $this->crm_brevo->list_modules( $this->settings );
+		$this->assertIsArray( $modules );
+		$this->assertEmpty( $modules );
+	}
+
+	// -------------------------------------------------------------------------
+	// list_fields tests.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns a non-empty array of fields.
+	 */
+	public function test_list_fields_returns_fields() {
+		$fields = $this->crm_brevo->list_fields( $this->settings, '' );
+		$this->assertIsArray( $fields );
+		$this->assertNotEmpty( $fields );
+	}
+
+	/**
+	 * email and ext_id are always present as the first two fields.
+	 */
+	public function test_list_fields_always_includes_email_and_ext_id() {
+		$fields = $this->crm_brevo->list_fields( $this->settings, '' );
+		$names  = array_column( $fields, 'name' );
+		$this->assertContains( 'email', $names );
+		$this->assertContains( 'ext_id', $names );
+	}
+
+	/**
+	 * Global category attributes are excluded from the field map.
+	 */
+	public function test_list_fields_excludes_global_category() {
+		$fields = $this->crm_brevo->list_fields( $this->settings, '' );
+		$names  = array_column( $fields, 'name' );
+		// These are in the mock data with category=global.
+		$this->assertNotContains( 'BLACKLIST', $names );
+		$this->assertNotContains( 'READERS', $names );
+		$this->assertNotContains( 'CLICKERS', $names );
+	}
+
+	/**
+	 * EXT_ID attribute from attributes list is not duplicated (already added manually).
+	 */
+	public function test_list_fields_ext_id_not_duplicated() {
+		$fields = $this->crm_brevo->list_fields( $this->settings, '' );
+		$names  = array_column( $fields, 'name' );
+		$count  = array_count_values( $names );
+		$this->assertSame( 1, $count['ext_id'] );
+	}
+
+	/**
+	 * Normal and transactional attributes are included.
+	 */
+	public function test_list_fields_includes_normal_and_transactional_attributes() {
+		$fields = $this->crm_brevo->list_fields( $this->settings, '' );
+		$names  = array_column( $fields, 'name' );
+		// Normal attributes.
+		$this->assertContains( 'NOMBRE', $names );
+		$this->assertContains( 'PHONE', $names );
+		// Transactional attributes.
+		$this->assertContains( 'ORDER_ID', $names );
+		$this->assertContains( 'ORDER_DATE', $names );
+	}
+
+	/**
+	 * Each field entry has a label and a name key.
+	 */
+	public function test_list_fields_entries_have_label_and_name() {
+		$fields = $this->crm_brevo->list_fields( $this->settings, '' );
+		foreach ( $fields as $field ) {
+			$this->assertArrayHasKey( 'label', $field );
+			$this->assertArrayHasKey( 'name', $field );
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// create_entry tests.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Successful create_entry returns status ok with an id.
+	 */
+	public function test_create_entry_returns_ok_with_id() {
+		$merge_vars = array(
+			array( 'name' => 'email', 'value' => 'contact@example.com' ),
+			array( 'name' => 'NOMBRE', 'value' => 'Jane' ),
+		);
+		$result = $this->crm_brevo->create_entry( $this->settings, $merge_vars );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'ok', $result['status'] );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertSame( 42, $result['id'] );
+	}
+
+	/**
+	 * email is placed at root level of the POST body, not inside attributes.
+	 */
+	public function test_create_entry_email_at_root_level() {
+		$merge_vars = array(
+			array( 'name' => 'email', 'value' => 'contact@example.com' ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertNotNull( $body );
+		$this->assertArrayHasKey( 'email', $body );
+		$this->assertSame( 'contact@example.com', $body['email'] );
+		$this->assertArrayNotHasKey( 'email', $body['attributes'] ?? array() );
+	}
+
+	/**
+	 * ext_id is placed at root level of the POST body.
+	 */
+	public function test_create_entry_ext_id_at_root_level() {
+		$merge_vars = array(
+			array( 'name' => 'email',  'value' => 'contact@example.com' ),
+			array( 'name' => 'ext_id', 'value' => 'user-123' ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertArrayHasKey( 'ext_id', $body );
+		$this->assertSame( 'user-123', $body['ext_id'] );
+	}
+
+	/**
+	 * Custom attribute fields are placed inside the attributes object.
+	 */
+	public function test_create_entry_custom_field_placed_in_attributes() {
+		$merge_vars = array(
+			array( 'name' => 'email',  'value' => 'contact@example.com' ),
+			array( 'name' => 'NOMBRE', 'value' => 'Jane' ),
+			array( 'name' => 'PHONE',  'value' => '600000000' ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertArrayHasKey( 'attributes', $body );
+		$this->assertArrayHasKey( 'NOMBRE', $body['attributes'] );
+		$this->assertSame( 'Jane', $body['attributes']['NOMBRE'] );
+		$this->assertArrayHasKey( 'PHONE', $body['attributes'] );
+	}
+
+	/**
+	 * Fields using legacy attributes|FIELDNAME prefix are correctly mapped.
+	 */
+	public function test_create_entry_legacy_pipe_prefix_mapped_to_attributes() {
+		$merge_vars = array(
+			array( 'name' => 'email',             'value' => 'contact@example.com' ),
+			array( 'name' => 'attributes|CIUDAD',  'value' => 'Madrid' ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertArrayHasKey( 'attributes', $body );
+		$this->assertArrayHasKey( 'CIUDAD', $body['attributes'] );
+		$this->assertSame( 'Madrid', $body['attributes']['CIUDAD'] );
+	}
+
+	/**
+	 * listIds always contains the module id from settings.
+	 */
+	public function test_create_entry_list_id_from_settings() {
+		$merge_vars = array(
+			array( 'name' => 'email', 'value' => 'contact@example.com' ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertArrayHasKey( 'listIds', $body );
+		$this->assertContains( 10, $body['listIds'] );
+	}
+
+	/**
+	 * updateEnabled is always sent as true.
+	 */
+	public function test_create_entry_update_enabled_is_true() {
+		$merge_vars = array(
+			array( 'name' => 'email', 'value' => 'contact@example.com' ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertArrayHasKey( 'updateEnabled', $body );
+		$this->assertTrue( $body['updateEnabled'] );
+	}
+
+	/**
+	 * API error on create_entry returns error array.
+	 */
+	public function test_create_entry_on_api_error_returns_error() {
+		$this->mock_mode = 'error';
+		$merge_vars      = array(
+			array( 'name' => 'email', 'value' => 'contact@example.com' ),
+		);
+		$result = $this->crm_brevo->create_entry( $this->settings, $merge_vars );
+		$this->assertIsArray( $result );
+		$this->assertSame( 'error', $result['status'] );
+	}
+
+	/**
+	 * Data provider: standard fields that must go to root level.
+	 *
+	 * @return array
+	 */
+	public function standard_fields_provider() {
+		return array(
+			'emailBlacklisted'   => array( 'emailBlacklisted',   false ),
+			'smsBlacklisted'     => array( 'smsBlacklisted',     false ),
+			'updateEnabled'      => array( 'updateEnabled',      false ),
+		);
+	}
+
+	/**
+	 * Standard boolean fields are placed at root level, never inside attributes.
+	 *
+	 * @dataProvider standard_fields_provider
+	 * @param string $field_name  Field name.
+	 * @param mixed  $field_value Field value to send.
+	 */
+	public function test_create_entry_standard_field_stays_at_root( $field_name, $field_value ) {
+		$merge_vars = array(
+			array( 'name' => 'email',     'value' => 'contact@example.com' ),
+			array( 'name' => $field_name, 'value' => $field_value ),
+		);
+		$this->crm_brevo->create_entry( $this->settings, $merge_vars );
+
+		$body = $this->last_request_body;
+		$this->assertArrayHasKey( $field_name, $body );
+		$this->assertArrayNotHasKey( $field_name, $body['attributes'] ?? array() );
+	}
+}

--- a/tests/Data/brevo-get-contacts-attributes.json
+++ b/tests/Data/brevo-get-contacts-attributes.json
@@ -1,0 +1,400 @@
+{
+	"attributes": [
+		{
+			"name": "PS_LAST_30_DAYS_CA",
+			"category": "calculated",
+			"type": "float",
+			"calculatedValue": "SUM[ORDER_PRICE,ORDER_DATE,>,NOW(-30)]"
+		},
+		{
+			"name": "PS_CA_USER",
+			"category": "calculated",
+			"type": "float",
+			"calculatedValue": "SUM[ORDER_PRICE]"
+		},
+		{
+			"name": "PS_ORDER_TOTAL",
+			"category": "calculated",
+			"type": "float",
+			"calculatedValue": "COUNT[ORDER_ID]"
+		},
+		{
+			"name": "WC_LAST_30_DAYS_CA",
+			"category": "calculated",
+			"type": "float",
+			"calculatedValue": "SUM[ORDER_PRICE,ORDER_DATE,>,NOW(-30)]"
+		},
+		{
+			"name": "WC_CA_USER",
+			"category": "calculated",
+			"type": "float",
+			"calculatedValue": "SUM[ORDER_PRICE]"
+		},
+		{
+			"name": "WC_ORDER_TOTAL",
+			"category": "calculated",
+			"type": "float",
+			"calculatedValue": "COUNT[ORDER_ID]"
+		},
+		{
+			"name": "BLACKLIST",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "COUNT[BLACKLISTED,BLACKLISTED,<,NOW()]"
+		},
+		{
+			"name": "READERS",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "COUNT[READERS,READERS,<,NOW()]"
+		},
+		{
+			"name": "CLICKERS",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "COUNT[CLICKERS,CLICKERS,<,NOW()]"
+		},
+		{
+			"name": "PS_CA_LAST_30DAYS",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[PS_LAST_30_DAYS_CA]"
+		},
+		{
+			"name": "PS_CA_TOTAL",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[PS_CA_USER]"
+		},
+		{
+			"name": "PS_ORDERS_COUNT",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[PS_ORDER_TOTAL]"
+		},
+		{
+			"name": "PROXY_OPENS",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[ORDER_PRICE,ORDER_DATE,>,NOW(-30)]"
+		},
+		{
+			"name": "DELIVERED",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[ORDER_PRICE]"
+		},
+		{
+			"name": "RETURN_PATH",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "COUNT[ORDER_ID]"
+		},
+		{
+			"name": "WC_CA_LAST_30DAYS",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[WC_LAST_30_DAYS_CA]"
+		},
+		{
+			"name": "WC_CA_TOTAL",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[WC_CA_USER]"
+		},
+		{
+			"name": "WC_ORDERS_COUNT",
+			"category": "global",
+			"type": "float",
+			"calculatedValue": "SUM[WC_ORDER_TOTAL]"
+		},
+		{
+			"name": "ORDER_ID",
+			"category": "transactional",
+			"type": "id"
+		},
+		{
+			"name": "ORDER_DATE",
+			"category": "transactional",
+			"type": "date"
+		},
+		{
+			"name": "ORDER_PRICE",
+			"category": "transactional",
+			"type": "float"
+		},
+		{
+			"name": "ENCUESTA_QUE_TE_FALTO",
+			"category": "transactional",
+			"type": "text"
+		},
+		{
+			"name": "NUMERO_DE_PEDIDOS",
+			"category": "transactional",
+			"type": "float"
+		},
+		{
+			"name": "NOMBRE",
+			"category": "normal",
+			"type": "text",
+			"field_key": "lastname"
+		},
+		{
+			"name": "SURNAME",
+			"category": "normal",
+			"type": "text",
+			"field_key": "firstname"
+		},
+		{
+			"name": "SMS",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CIV",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "NAME",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "BIRTHDAY",
+			"category": "normal",
+			"type": "date"
+		},
+		{
+			"name": "PS_LANG",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "GROUP_ID",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "STORE_ID",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CLIENT",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "DEFAULT_GROUP_ID",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "DOUBLE_OPT-IN",
+			"category": "category",
+			"enumeration": [
+				{
+					"value": 2,
+					"valueStr": "2",
+					"label": "No"
+				},
+				{
+					"value": 1,
+					"valueStr": "1",
+					"label": "Yes"
+				}
+			]
+		},
+		{
+			"name": "OPT_IN",
+			"category": "normal",
+			"type": "boolean"
+		},
+		{
+			"name": "GENDER",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "PHONE",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "SUBSCRIBED",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "EXT_ID",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CONTACT_TIMEZONE",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "JOB_TITLE",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "LINKEDIN",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "PRODUCTO",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CIUDAD",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "PROVINCIA",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "PAIS",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "WC_USER_ID",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "LANDLINE_NUMBER",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "WC_SUBSCRIPTION_STATUS",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "WC_DOUBLE_OPTED",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "WC_SUBSCRIPTION_LOCATION",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "WC_SHOP_URL",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CONTACT_SOURCE",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CONTACTO",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "ETAPA",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CODIGO_POSTAL",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "CANTIDAD_PEDIDOS",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "RFM_SEGMENT",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "RFM_RECENCY_DAYS",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "RFM_FREQUENCY",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "RFM_MONETARY",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "RFM_LAST_ORDER_DATE",
+			"category": "normal",
+			"type": "date"
+		},
+		{
+			"name": "RFM_UPDATED_AT",
+			"category": "normal",
+			"type": "date"
+		},
+		{
+			"name": "CRM_LIFECYCLE_STAGE",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CRM_LIFECYCLE_UPDATED_AT",
+			"category": "normal",
+			"type": "date"
+		},
+		{
+			"name": "CRM_FIRST_ORDER_DATE",
+			"category": "normal",
+			"type": "date"
+		},
+		{
+			"name": "CRM_ORDER_COUNT",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "CRM_TOTAL_SPENT",
+			"category": "normal",
+			"type": "float"
+		},
+		{
+			"name": "CRM_CAN_EMAIL",
+			"category": "normal",
+			"type": "boolean"
+		},
+		{
+			"name": "CRM_CONTACTABILITY_STATUS",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CRM_CONTACTABILITY_REASON",
+			"category": "normal",
+			"type": "text"
+		},
+		{
+			"name": "CRM_LAST_CONTACTABILITY_CHECK",
+			"category": "normal",
+			"type": "date"
+		}
+	]
+}

--- a/tests/Data/brevo-get-contacts-lists.json
+++ b/tests/Data/brevo-get-contacts-lists.json
@@ -1,0 +1,85 @@
+{
+	"lists": [
+		{
+			"id": 10,
+			"name": "Test List A",
+			"folderId": 1,
+			"uniqueSubscribers": 300,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 11,
+			"name": "Test List B",
+			"folderId": 1,
+			"uniqueSubscribers": 1500,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 12,
+			"name": "Test List C",
+			"folderId": 1,
+			"uniqueSubscribers": 1800,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 13,
+			"name": "Test List D",
+			"folderId": 1,
+			"uniqueSubscribers": 900,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 14,
+			"name": "Test List E",
+			"folderId": 1,
+			"uniqueSubscribers": 2000,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 15,
+			"name": "Test List F",
+			"folderId": 1,
+			"uniqueSubscribers": 4300,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 16,
+			"name": "Test List G",
+			"folderId": 1,
+			"uniqueSubscribers": 14000,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 17,
+			"name": "Test List H",
+			"folderId": 1,
+			"uniqueSubscribers": 1100,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 18,
+			"name": "Test List I",
+			"folderId": 1,
+			"uniqueSubscribers": 2500,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		},
+		{
+			"id": 19,
+			"name": "Test List J",
+			"folderId": 2,
+			"uniqueSubscribers": 1400,
+			"totalBlacklisted": 0,
+			"totalSubscribers": 0
+		}
+	],
+	"count": 64
+}


### PR DESCRIPTION
Problem
The fc_crm_module dropdown in Contact Form 7 (and other form plugins) only displayed 10 lists from Brevo, even though the account had 87 lists. The API response showed count: 87, confirming all lists existed but weren't being fetched.

Root Cause
The api() method in CRMLIB_Brevo had three chained bugs in its GET pagination logic:

Missing URL parameters: Query string params ?limit=N&offset=N were commented out, so every API request hit the same endpoint without pagination parameters. Brevo defaults to 10 items when no limit is specified.

Loop never repeats: The repeat_query condition compared count($result['data']) (which was 10) against a hardcoded $limit of 100, causing the loop to exit after one iteration.

Broken data accumulation: The method tried to merge entire response envelopes ({lists: [...], count: 87}) instead of just the nested items array, then list_modules() looked for ['data']['lists'] in a structure that no longer had that nesting.

Solution
Modified /includes/crm-library/class-crmlib-brevo.php:

In api() GET block:

Append ?limit=50&offset=N to the URL for each request
Extract nested items ($result['data']['lists']) from the response, or fall back to $result['data'] if not nested
Accumulate only items (not envelopes) in $result_data
Use $offset < $total to control pagination loop continuation
In list_modules():

Read $result_lists['data'] directly as a flat array (changed from $result_lists['data']['lists'])
Impact
✅ Dropdown now displays all 87 lists instead of 10
✅ Backwards compatible: Other Brevo endpoints like contacts/attributes continue working because the extraction logic safely detects nested vs flat responses
✅ Pagination now works for any endpoint with paginated results
Testing
Open Contact Form 7 with Brevo connected
Navigate to CRM settings
Verify CRM Module dropdown shows all 87 lists (scroll through dropdown)
Verify field mapping still works (check that custom fields load correctly)