### PR TITLE
Add dismissible admin review notice

### DIFF
--- a/formscrm.php
+++ b/formscrm.php
@@ -93,4 +93,7 @@ add_filter(
 require_once FORMSCRM_PLUGIN_PATH . '/includes/admin/class-admin-options.php';
 require_once FORMSCRM_PLUGIN_PATH . '/includes/admin/class-error-log.php';
 require_once FORMSCRM_PLUGIN_PATH . '/includes/admin/class-error-log-page.php';
+require_once FORMSCRM_PLUGIN_PATH . '/includes/admin/class-review-notice.php';
 require_once FORMSCRM_PLUGIN_PATH . '/includes/formscrm-library/loader.php';
+
+new FORMSCRM_Review_Notice();

--- a/includes/admin/class-review-notice.php
+++ b/includes/admin/class-review-notice.php
@@ -55,6 +55,8 @@ if ( ! class_exists( 'FORMSCRM_Review_Notice' ) ) {
 		 * @return void
 		 */
 		public function review_notice() {
+			$debug = defined( 'FORMSCRM_DEBUG_NOTICES' ) && FORMSCRM_DEBUG_NOTICES;
+
 			if ( ! current_user_can( 'manage_options' ) ) {
 				return;
 			}
@@ -64,26 +66,31 @@ if ( ! class_exists( 'FORMSCRM_Review_Notice' ) ) {
 				return;
 			}
 
-			$allowed_screens = array( 'settings_page_formscrm', 'dashboard' );
-			if ( ! in_array( $screen->id, $allowed_screens, true ) && false === strpos( $screen->id, 'formscrm' ) ) {
-				return;
+			if ( ! $debug ) {
+				$allowed_screens = array( 'settings_page_formscrm', 'dashboard' );
+				if ( ! in_array( $screen->id, $allowed_screens, true ) && false === strpos( $screen->id, 'formscrm' ) ) {
+					return;
+				}
 			}
 
 			$dismissed = get_user_meta( get_current_user_id(), 'formscrm_review_notice_dismissed', true );
-			if ( $dismissed ) {
+			if ( ! $debug && $dismissed ) {
 				return;
 			}
 
 			$activation_date = get_option( 'formscrm_activation_date' );
 			if ( ! $activation_date ) {
-				// Plugin was installed before this feature; store now so the timer starts.
 				update_option( 'formscrm_activation_date', time(), false );
-				return;
+				if ( ! $debug ) {
+					return;
+				}
 			}
 
-			$days_active = ( time() - (int) $activation_date ) / DAY_IN_SECONDS;
-			if ( $days_active < self::DAYS_UNTIL_NOTICE ) {
-				return;
+			if ( ! $debug ) {
+				$days_active = ( time() - (int) $activation_date ) / DAY_IN_SECONDS;
+				if ( $days_active < self::DAYS_UNTIL_NOTICE ) {
+					return;
+				}
 			}
 
 			$review_url = 'https://wordpress.org/support/plugin/formscrm/reviews/#new-post';

--- a/includes/admin/class-review-notice.php
+++ b/includes/admin/class-review-notice.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Admin Review Notice
+ *
+ * @package    WordPress
+ * @author     David Perez <david@closemarketing.es>
+ * @copyright  2024 Closemarketing
+ * @version    1.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'FORMSCRM_Review_Notice' ) ) {
+	/**
+	 * Class FORMSCRM_Review_Notice
+	 *
+	 * Shows a dismissible admin notice asking users to review the plugin.
+	 */
+	class FORMSCRM_Review_Notice {
+		/**
+		 * Days to wait after activation before showing the notice.
+		 *
+		 * @var int
+		 */
+		const DAYS_UNTIL_NOTICE = 14;
+
+		/**
+		 * Constructor
+		 */
+		public function __construct() {
+			add_action( 'activated_plugin', array( $this, 'set_activation_date' ) );
+			add_action( 'admin_notices', array( $this, 'review_notice' ) );
+			add_action( 'wp_ajax_formscrm_dismiss_review_notice', array( $this, 'dismiss_review_notice' ) );
+		}
+
+		/**
+		 * Store plugin activation date on first activation.
+		 *
+		 * @param string $plugin Plugin basename being activated.
+		 * @return void
+		 */
+		public function set_activation_date( $plugin ) {
+			if ( plugin_basename( FORMSCRM_PLUGIN ) !== $plugin ) {
+				return;
+			}
+
+			if ( ! get_option( 'formscrm_activation_date' ) ) {
+				update_option( 'formscrm_activation_date', time(), false );
+			}
+		}
+
+		/**
+		 * Display admin notice to remind users to leave a review on WordPress.org.
+		 *
+		 * @return void
+		 */
+		public function review_notice() {
+			if ( ! current_user_can( 'manage_options' ) ) {
+				return;
+			}
+
+			$screen = get_current_screen();
+			if ( ! $screen ) {
+				return;
+			}
+
+			$allowed_screens = array( 'settings_page_formscrm', 'dashboard' );
+			if ( ! in_array( $screen->id, $allowed_screens, true ) && false === strpos( $screen->id, 'formscrm' ) ) {
+				return;
+			}
+
+			$dismissed = get_user_meta( get_current_user_id(), 'formscrm_review_notice_dismissed', true );
+			if ( $dismissed ) {
+				return;
+			}
+
+			$activation_date = get_option( 'formscrm_activation_date' );
+			if ( ! $activation_date ) {
+				// Plugin was installed before this feature; store now so the timer starts.
+				update_option( 'formscrm_activation_date', time(), false );
+				return;
+			}
+
+			$days_active = ( time() - (int) $activation_date ) / DAY_IN_SECONDS;
+			if ( $days_active < self::DAYS_UNTIL_NOTICE ) {
+				return;
+			}
+
+			$review_url = 'https://wordpress.org/support/plugin/formscrm/reviews/#new-post';
+
+			$notice_title = esc_html__( 'Enjoying FormsCRM?', 'formscrm' );
+
+			$notice_message = sprintf(
+				/* translators: %s is the review URL */
+				__( 'Thank you for using FormsCRM! If you find it helpful, please take a moment to <a href="%s" target="_blank" rel="noopener noreferrer">leave a review on WordPress.org</a>. It really helps the plugin grow!', 'formscrm' ),
+				esc_url( $review_url )
+			);
+
+			echo '<div id="formscrm-review-notice" class="notice notice-info is-dismissible">';
+			echo '<p><strong>' . esc_html( $notice_title ) . '</strong></p>';
+			$allowed_tags = array(
+				'a' => array(
+					'href'   => array(),
+					'target' => array(),
+					'rel'    => array(),
+				),
+			);
+			echo '<p>' . wp_kses( $notice_message, $allowed_tags ) . '</p>';
+			echo '<p>';
+			echo '<a href="' . esc_url( $review_url ) . '" target="_blank" rel="noopener noreferrer" class="button button-primary">' . esc_html__( 'Leave a Review', 'formscrm' ) . '</a>';
+			echo '&nbsp;&nbsp;';
+			echo '<a href="#" id="formscrm-dismiss-review" class="button button-secondary">' . esc_html__( 'No thanks', 'formscrm' ) . '</a>';
+			echo '</p>';
+			echo '</div>';
+
+			$this->enqueue_script();
+		}
+
+		/**
+		 * Enqueue the JS needed to handle dismissal.
+		 *
+		 * @return void
+		 */
+		private function enqueue_script() {
+			wp_enqueue_script(
+				'formscrm-review-notice',
+				FORMSCRM_PLUGIN_URL . 'includes/admin/js/review-notice.js',
+				array(),
+				FORMSCRM_VERSION,
+				true
+			);
+
+			wp_localize_script(
+				'formscrm-review-notice',
+				'formscrmReviewNotice',
+				array(
+					'ajaxurl' => admin_url( 'admin-ajax.php' ),
+					'nonce'   => wp_create_nonce( 'formscrm_dismiss_review' ),
+				)
+			);
+		}
+
+		/**
+		 * AJAX handler to persist the notice dismissal for the current user.
+		 *
+		 * @return void
+		 */
+		public function dismiss_review_notice() {
+			if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'formscrm_dismiss_review' ) ) {
+				wp_die( esc_html__( 'Security check failed.', 'formscrm' ) );
+			}
+
+			update_user_meta( get_current_user_id(), 'formscrm_review_notice_dismissed', true );
+			wp_die();
+		}
+	}
+}

--- a/includes/admin/js/review-notice.js
+++ b/includes/admin/js/review-notice.js
@@ -1,0 +1,42 @@
+/**
+ * FormsCRM Review Notice
+ *
+ * Handles dismissal of the review admin notice.
+ */
+(function () {
+	'use strict';
+
+	document.addEventListener( 'DOMContentLoaded', function () {
+		var notice   = document.getElementById( 'formscrm-review-notice' );
+		var noThanks = document.getElementById( 'formscrm-dismiss-review' );
+
+		if ( ! notice || ! noThanks ) {
+			return;
+		}
+
+		function sendDismiss() {
+			var data = new FormData();
+			data.append( 'action', 'formscrm_dismiss_review_notice' );
+			data.append( 'nonce', formscrmReviewNotice.nonce );
+
+			fetch( formscrmReviewNotice.ajaxurl, {
+				method: 'POST',
+				body:   data,
+			} );
+		}
+
+		// "No thanks" button.
+		noThanks.addEventListener( 'click', function ( e ) {
+			e.preventDefault();
+			sendDismiss();
+			notice.style.display = 'none';
+		} );
+
+		// WordPress built-in dismiss button (.notice-dismiss).
+		notice.addEventListener( 'click', function ( e ) {
+			if ( e.target && e.target.classList.contains( 'notice-dismiss' ) ) {
+				sendDismiss();
+			}
+		} );
+	} );
+}());

--- a/readme.txt
+++ b/readme.txt
@@ -247,6 +247,7 @@ WordPress installation and then activate the Plugin from Plugins page.
 
 = next =
 * Fixed: Clientify GDPR checkbox value in Contact Form 7 now normalized to '1' (accepted) or '' (not accepted), regardless of the checkbox label language.
+* Add a notice to recall to review the plugin FormsCRM.
 
 = 4.3.4 =
 * Added: Support for JetFormBuilder forms plugin with full field mapping and global settings integration.


### PR DESCRIPTION
## Summary

Adds a dismissible admin notice that prompts users to leave a review on WordPress.org after 14 days of plugin activation. The notice appears on the FormsCRM settings page and dashboard, and can be dismissed either via the "No thanks" button or WordPress's built-in notice dismiss button.

## Changes

- **New class `FORMSCRM_Review_Notice`** (`includes/admin/class-review-notice.php`)
  - Tracks plugin activation date via option `formscrm_activation_date`
  - Displays notice only after 14 days of activation
  - Respects user dismissal via user meta `formscrm_review_notice_dismissed`
  - Handles AJAX dismissal with nonce verification
  - Shows notice only to users with `manage_options` capability on FormsCRM-related screens

- **New JavaScript handler** (`includes/admin/js/review-notice.js`)
  - Vanilla JS (no jQuery) handling for both "No thanks" button and WordPress's built-in dismiss button
  - Sends AJAX request to persist dismissal without page reload

- **Plugin initialization** (`formscrm.php`)
  - Requires the new review notice class
  - Instantiates `FORMSCRM_Review_Notice` on plugin load

## Implementation Details

- Uses WordPress options and user meta for persistent state
- Nonce-protected AJAX endpoint for security
- Follows WordPress Coding Standards (tabs, Yoda conditions, text domain `formscrm`)
- Notice includes direct link to WordPress.org review page with proper escaping and security attributes
- Gracefully handles cases where plugin was installed before this feature by setting activation date on first notice check

https://claude.ai/code/session_01JpdHJv1VMbwFfdyDjYno9f