### PR TITLE
Fix: skip empty custom_fields when sending data to Clientify API

### DIFF
--- a/formscrm.php
+++ b/formscrm.php
@@ -3,7 +3,7 @@
  * Plugin Name: FormsCRM
  * Plugin URI : https://close.technology/wordpress-plugins/formscrm/
  * Description: Connects Forms with CRM, ERP and Email Marketing.
- * Version: 4.3.4-beta.4
+ * Version: 4.3.4-beta.5
  * Author: CloseTechnology
  * Author URI: https://close.technology
  * Text Domain: formscrm
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
-define( 'FORMSCRM_VERSION', '4.3.4-beta.3' );
+define( 'FORMSCRM_VERSION', '4.3.4-beta.5' );
 define( 'FORMSCRM_PLUGIN', __FILE__ );
 define( 'FORMSCRM_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'FORMSCRM_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/crm-library/class-crmlib-clientify.php
+++ b/includes/crm-library/class-crmlib-clientify.php
@@ -725,19 +725,23 @@ class CRMLIB_Clientify {
 				$element['value'] = implode( ',', $element['value'] );
 			}
 			if ( strpos( $element['name'], '|' ) && 0 === strpos( $element['name'], 'deal|custom_fields' ) ) {
-				$custom_field            = explode( '|', $element['name'] );
-				$deal['custom_fields'][] = array(
-					'field' => $custom_field[2],
-					'value' => $element['value'],
-				);
+				if ( '' !== $element['value'] ) {
+					$custom_field            = explode( '|', $element['name'] );
+					$deal['custom_fields'][] = array(
+						'field' => $custom_field[2],
+						'value' => $element['value'],
+					);
+				}
 			} elseif ( strpos( $element['name'], '|' ) && 0 === strpos( $element['name'], 'deal' ) ) {
 				$this->parse_deal_field( $element, $deal, $deal_product_skus, $deal_tags );
 			} elseif ( strpos( $element['name'], '|' ) && 0 === strpos( $element['name'], 'custom_fields' ) ) {
-				$custom_field               = explode( '|', $element['name'] );
-				$contact['custom_fields'][] = array(
-					'field' => $custom_field[1],
-					'value' => $element['value'],
-				);
+				if ( '' !== $element['value'] ) {
+					$custom_field               = explode( '|', $element['name'] );
+					$contact['custom_fields'][] = array(
+						'field' => $custom_field[1],
+						'value' => $element['value'],
+					);
+				}
 			} elseif ( strpos( $element['name'], '|' ) && 0 === strpos( $element['name'], 'emails' ) ) {
 				$email               = explode( '|', $element['name'] );
 				$contact['emails'][] = array(

--- a/includes/formscrm-library/class-contactform7.php
+++ b/includes/formscrm-library/class-contactform7.php
@@ -174,7 +174,7 @@ class FORMSCRM_CF7_Settings {
 					</p>
 					<p>
 						<label for="wpcf7-crm-fc_crm_mode_expert"><?php esc_html_e( 'Expert Mode', 'formscrm' ); ?></label><br />
-						<input type="checkbox" id="wpcf7-crm-fc_crm_mode_expert" name="wpcf7-crm[fc_crm_mode_expert]" class="medium" value="on" <?php checked( $cf7_crm['fc_crm_mode_expert'], 'on' ); ?> /><?php esc_html_e( 'Enable this option to show all fields of the CRM.', 'formscrm' ); ?>
+						<input type="checkbox" id="wpcf7-crm-fc_crm_mode_expert" name="wpcf7-crm[fc_crm_mode_expert]" class="medium" value="on" <?php checked( isset( $cf7_crm['fc_crm_mode_expert'] ) ? $cf7_crm['fc_crm_mode_expert'] : '', 'on' ); ?> /><?php esc_html_e( 'Enable this option to show all fields of the CRM.', 'formscrm' ); ?>
 					</p>
 				<?php } ?>
 			</div>
@@ -186,11 +186,8 @@ class FORMSCRM_CF7_Settings {
 
 			if ( ! empty( $this->crmlib ) ) {
 				$login_crm = $this->crmlib->login( $cf7_crm );
-				if ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) {
+				if ( ! $login_crm || ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) ) {
 					echo '<p style="color: red;">' . esc_html( $login_crm['message'] ) . '</p>';
-					return;
-				}
-				if ( true !== $login_crm && false !== $login_crm ) {
 					return;
 				}
 			}

--- a/includes/formscrm-library/class-gravityforms.php
+++ b/includes/formscrm-library/class-gravityforms.php
@@ -550,7 +550,7 @@ class GFCRM extends GFFeedAddOn {
 			'type'  => 'feed_connection_status',
 		);
 
-		if ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) {
+		if ( ! $login_crm || ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) ) {
 			return $crm_feed_fields;
 		}
 

--- a/includes/formscrm-library/class-jetformbuilder.php
+++ b/includes/formscrm-library/class-jetformbuilder.php
@@ -241,7 +241,7 @@ function formscrm_jfb_rest_get_fields( $request ) {
 	}
 
 	$login = $crmlib->login( $settings );
-	if ( is_array( $login ) && isset( $login['status'] ) && 'error' === $login['status'] ) {
+	if ( ! $login || ( is_array( $login ) && isset( $login['status'] ) && 'error' === $login['status'] ) ) {
 		return new WP_Error( 'login_failed', $login['message'], array( 'status' => 400 ) );
 	}
 

--- a/includes/formscrm-library/class-woocommerce.php
+++ b/includes/formscrm-library/class-woocommerce.php
@@ -208,11 +208,7 @@ class FormsCRM_WooCommerce {
 
 		if ( ! empty( $this->crmlib ) && ! empty( $wc_formscrm ) ) {
 			$login_crm = $this->crmlib->login( $wc_formscrm );
-			if ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) {
-				return $settings_crm;
-			}
-
-			if ( false === $login_crm ) {
+			if ( ! $login_crm || ( is_array( $login_crm ) && isset( $login_crm['status'] ) && 'error' === $login_crm['status'] ) ) {
 				return $settings_crm;
 			}
 		}

--- a/includes/formscrm-library/class-wpforms.php
+++ b/includes/formscrm-library/class-wpforms.php
@@ -331,12 +331,8 @@ class FormsCRM_WPForms extends WPForms_Provider {
 		if ( isset( $this->crmlib ) ) {
 			$login_result = $this->crmlib->login( $data );
 		}
-		if ( is_array( $login_result ) && isset( $login_result['status'] ) && 'error' === $login_result['status'] ) {
+		if ( ! $login_result || ( is_array( $login_result ) && isset( $login_result['status'] ) && 'error' === $login_result['status'] ) ) {
 			return $this->error( esc_html__( 'We could not login to the CRM', 'formscrm' ) . ' ' . esc_html( $login_result['message'] ) );
-		}
-
-		if ( isset( $login_result ) && false === $login_result ) {
-			return $this->error( 'API authorization error: ' . $data['fc_crm_type'] );
 		}
 
 		$id                              = uniqid();
@@ -454,7 +450,7 @@ class FormsCRM_WPForms extends WPForms_Provider {
 			$login_result = $this->crmlib->login( $settings );
 		}
 
-		if ( ! $login_result ) {
+		if ( ! $login_result || ( is_array( $login_result ) && isset( $login_result['status'] ) && 'error' === $login_result['status'] ) ) {
 			$this->error( __( 'Could not connect to CRM.', 'formscrm' ) );
 		}
 

--- a/includes/formscrm-library/helpers-functions.php
+++ b/includes/formscrm-library/helpers-functions.php
@@ -645,7 +645,7 @@ if ( ! function_exists( 'formscrm_check_connection_status' ) ) {
 		$login_result = $crmlib->login( $settings );
 		$login_status = isset( $login_result['status'] ) ? $login_result['status'] : '';
 
-		if ( is_array( $login_result ) && 'error' === $login_status ) {
+		if ( ! $login_result || ( is_array( $login_result ) && isset( $login_result['status'] ) && 'error' === $login_result['status'] ) ) {
 			$data['status']        = 'error';
 			$data['text']          = __( 'Error', 'formscrm' );
 			$data['color']         = '#dc3232';

--- a/readme.txt
+++ b/readme.txt
@@ -248,9 +248,8 @@ WordPress installation and then activate the Plugin from Plugins page.
 = next =
 * Fixed: Clientify GDPR checkbox value in Contact Form 7 now normalized to '1' (accepted) or '' (not accepted), regardless of the checkbox label language.
 * Add a notice to recall to review the plugin FormsCRM.
-
-= 4.3.4 =
 * Added: Support for JetFormBuilder forms plugin with full field mapping and global settings integration.
+* Fixed: API Clientify error not add null values in custom fields.
 * Fixed: Elementor not getting correctly the module from settings.
 * Fixed: Normalize boolean CRM fields to standardized values for Clientify.
 * Fixed: CF7 "Saving..." spinner was always visible because wp_kses strips display:none from inline styles; moved visibility control to CSS class.

--- a/readme.txt
+++ b/readme.txt
@@ -250,6 +250,8 @@ WordPress installation and then activate the Plugin from Plugins page.
 * Add a notice to recall to review the plugin FormsCRM.
 * Added: Support for JetFormBuilder forms plugin with full field mapping and global settings integration.
 * Fixed: API Clientify error not add null values in custom fields.
+* Fixed: Error in CF7 value expert.
+* Fixed: Login error depending on the CRM, now it shows the error message from the CRM in the settings page.
 * Fixed: Elementor not getting correctly the module from settings.
 * Fixed: Normalize boolean CRM fields to standardized values for Clientify.
 * Fixed: CF7 "Saving..." spinner was always visible because wp_kses strips display:none from inline styles; moved visibility control to CSS class.

--- a/tests/API/test-clientify.php
+++ b/tests/API/test-clientify.php
@@ -387,4 +387,89 @@ class ClientifyTests extends WP_UnitTestCase {
 		$this->assertIsBool( $body['gdpr_accept'] );
 		$this->assertSame( $expected, $body['gdpr_accept'] );
 	}
+
+	/**
+	 * Contact custom_fields with an empty string value must NOT be sent to the API.
+	 */
+	public function test_create_entry_contact_custom_field_empty_string_is_skipped() {
+		$this->last_contact_body = null;
+
+		$merge_vars = array(
+			array( 'name' => 'email',                    'value' => 'test@example.com' ),
+			array( 'name' => 'custom_fields|my_field',   'value' => '' ),
+			array( 'name' => 'custom_fields|filled',     'value' => 'hello' ),
+		);
+
+		$this->crm_clientify->create_entry( $this->settings, $merge_vars );
+
+		$body          = $this->last_contact_body ?? array();
+		$custom_fields = $body['custom_fields'] ?? array();
+		$field_keys    = array_column( $custom_fields, 'field' );
+
+		$this->assertNotContains( 'my_field', $field_keys, 'Empty contact custom_field must not be sent.' );
+		$this->assertContains( 'filled', $field_keys, 'Non-empty contact custom_field must be sent.' );
+	}
+
+	/**
+	 * Contact custom_fields with a non-empty value must be sent to the API.
+	 */
+	public function test_create_entry_contact_custom_field_non_empty_is_sent() {
+		$this->last_contact_body = null;
+
+		$merge_vars = array(
+			array( 'name' => 'email',                  'value' => 'test@example.com' ),
+			array( 'name' => 'custom_fields|interest',  'value' => 'sports' ),
+		);
+
+		$this->crm_clientify->create_entry( $this->settings, $merge_vars );
+
+		$body          = $this->last_contact_body ?? array();
+		$custom_fields = $body['custom_fields'] ?? array();
+		$field_keys    = array_column( $custom_fields, 'field' );
+
+		$this->assertContains( 'interest', $field_keys );
+		$found = array_filter( $custom_fields, fn( $f ) => 'interest' === $f['field'] );
+		$this->assertSame( 'sports', array_values( $found )[0]['value'] );
+	}
+
+	/**
+	 * Deal custom_fields with an empty string value must NOT be sent to the API.
+	 */
+	public function test_create_entry_deal_custom_field_empty_string_is_skipped() {
+		$this->last_contact_body = null;
+		$this->settings['fc_crm_module'] = 'Contacts-Deals';
+
+		// Capture the deals/ POST body as well.
+		$last_deal_body = null;
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $r, $url ) use ( &$last_deal_body ) {
+				if ( 'POST' === $r['method'] && str_contains( $url, '/deals/' ) ) {
+					$last_deal_body = json_decode( $r['body'], true );
+					return array(
+						'body'     => '{"id":888}',
+						'response' => array( 'code' => 201, 'message' => 'Created' ),
+					);
+				}
+				return false;
+			},
+			5,
+			3
+		);
+
+		$merge_vars = array(
+			array( 'name' => 'email',                             'value' => 'test@example.com' ),
+			array( 'name' => 'deal|name',                         'value' => 'Test deal' ),
+			array( 'name' => 'deal|custom_fields|empty_field',    'value' => '' ),
+			array( 'name' => 'deal|custom_fields|filled_field',   'value' => 'value123' ),
+		);
+
+		$this->crm_clientify->create_entry( $this->settings, $merge_vars );
+
+		$deal_custom = $last_deal_body['custom_fields'] ?? array();
+		$field_keys  = array_column( $deal_custom, 'field' );
+
+		$this->assertNotContains( 'empty_field', $field_keys, 'Empty deal custom_field must not be sent.' );
+		$this->assertContains( 'filled_field', $field_keys, 'Non-empty deal custom_field must be sent.' );
+	}
 }


### PR DESCRIPTION
### Summary

- Contact `custom_fields` entries with an empty string value are no longer sent to the Clientify API, preventing the API from receiving blank field overwrites.
- The same guard is applied to `deal|custom_fields` entries.
- Added three PHPUnit tests to `ClientifyTests` covering both the skip-on-empty and send-on-non-empty cases for contact and deal custom fields.

### Test plan

- [x] Run `composer test --filter ClientifyTests` — all tests pass.
- [x] Submit a CF7 form mapped to a Clientify contact with some custom fields left blank — verify those fields are absent from the API payload.
- [x] Submit with all custom fields filled — verify all values are sent correctly.
