### PR TITLE
Improve retry scheduling to prevent duplicate jobs and log duplication

### DIFF
--- a/includes/admin/class-error-log-page.php
+++ b/includes/admin/class-error-log-page.php
@@ -100,6 +100,9 @@ if ( ! class_exists( 'FORMSCRM_Error_Log_Page' ) ) {
 					'bulkResendFailed'     => __( 'failed', 'formscrm' ),
 					'bulkResendDetails'    => __( 'Details', 'formscrm' ),
 					'ajaxError'            => __( 'AJAX Error', 'formscrm' ),
+					'confirmCancelRetries' => __( 'Are you sure you want to cancel all pending scheduled retries? Log entries will not be deleted.', 'formscrm' ),
+					'cancellingRetries'    => __( 'Cancelling...', 'formscrm' ),
+					'cancelAllRetries'     => __( 'Cancel All Scheduled Retries', 'formscrm' ),
 				)
 			);
 		}
@@ -195,6 +198,9 @@ if ( ! class_exists( 'FORMSCRM_Error_Log_Page' ) ) {
 
 						<button type="button" class="fcrm-button fcrm-button-danger" id="fcrm-clear-all-logs" style="margin-top: 10px;">
 							<?php esc_html_e( 'Clear All Logs', 'formscrm' ); ?>
+						</button>
+						<button type="button" class="fcrm-button fcrm-button-danger" id="fcrm-cancel-all-retries" style="margin-top: 10px;">
+							<?php esc_html_e( 'Cancel All Scheduled Retries', 'formscrm' ); ?>
 						</button>
 					</div>
 

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -27,6 +27,15 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 		private $table_name;
 
 		/**
+		 * Whether a retry execution is currently in progress.
+		 * Prevents insert_log() from creating a new row — and a new scheduler job —
+		 * when create_entry() internally triggers formscrm_alert_error().
+		 *
+		 * @var bool
+		 */
+		private $is_retrying = false;
+
+		/**
 		 * Constructor
 		 */
 		public function __construct() {
@@ -43,6 +52,9 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 
 			// Hook for automatic retry via Action Scheduler.
 			add_action( 'formscrm_retry_failed_entry', array( $this, 'retry_failed_entry' ), 10, 1 );
+
+			// Prevent Action Scheduler from retrying on its own; FormsCRM manages retries explicitly.
+			add_filter( 'action_scheduler_retry_failed_action', array( $this, 'disable_as_retry_for_formscrm' ), 10, 2 );
 		}
 
 		/**
@@ -55,20 +67,51 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			$retry_delay = HOUR_IN_SECONDS;
 			$timestamp   = time() + $retry_delay;
 
-			// Try Action Scheduler first.
 			if ( function_exists( 'as_schedule_single_action' ) ) {
+				// Skip if a pending AS action already exists for this log.
+				if ( as_has_scheduled_action( 'formscrm_retry_failed_entry', array( $log_id ) ) ) {
+					return;
+				}
 				try {
 					as_schedule_single_action( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
 					return;
 				} catch ( Exception $e ) {
-					// Fallback to WP-Cron.
-					wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
-					return;
+					formscrm_debug_message( "AS schedule failed for log {$log_id}, falling back to WP-Cron: {$e->getMessage()}" );
 				}
 			}
 
 			// Fallback to WP-Cron if Action Scheduler not available.
-			wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
+			if ( ! wp_next_scheduled( 'formscrm_retry_failed_entry', array( $log_id ) ) ) {
+				wp_schedule_single_event( $timestamp, 'formscrm_retry_failed_entry', array( $log_id ) );
+			}
+		}
+
+		/**
+		 * Cancel all pending retry actions for a log entry (Action Scheduler + WP-Cron).
+		 *
+		 * @param int $log_id Log ID.
+		 * @return void
+		 */
+		private function cancel_scheduled_retry( $log_id ) {
+			if ( function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( 'formscrm_retry_failed_entry', array( $log_id ) );
+			}
+			wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
+		}
+
+		/**
+		 * Prevent Action Scheduler from retrying formscrm_retry_failed_entry on its own.
+		 * FormsCRM manages retry scheduling explicitly via schedule_retry().
+		 *
+		 * @param int    $attempts Number of retries AS would make.
+		 * @param object $action   The AS action object.
+		 * @return int
+		 */
+		public function disable_as_retry_for_formscrm( $attempts, $action ) {
+			if ( 'formscrm_retry_failed_entry' === $action->get_hook() ) {
+				return 0;
+			}
+			return $attempts;
 		}
 
 		/**
@@ -134,6 +177,12 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 		 * @return int|false Log ID or false on failure.
 		 */
 		public function insert_log( $crm, $error, $data, $url = '', $json = '', $form_info = array() ) {
+			// Do not create a new log row during a retry: it would reset resend_attempts to 0
+			// and schedule an extra Action Scheduler job, bypassing the 3-attempt cap.
+			if ( $this->is_retrying ) {
+				return false;
+			}
+
 			global $wpdb;
 
 			$log_data = array(
@@ -320,8 +369,8 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 		public function delete_log( $log_id ) {
 			global $wpdb;
 
-			// Clear any scheduled retry before deleting.
-			wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
+			// Cancel any scheduled retry before deleting.
+			$this->cancel_scheduled_retry( $log_id );
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			return $wpdb->delete(
@@ -343,9 +392,9 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			$log_ids = $wpdb->get_col( "SELECT id FROM {$this->table_name}" );
 
-			// Clear scheduled retries for all logs.
+			// Cancel scheduled retries for all logs.
 			foreach ( $log_ids as $log_id ) {
-				wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
+				$this->cancel_scheduled_retry( $log_id );
 			}
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
@@ -430,8 +479,8 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				if ( isset( $response['status'] ) && 'ok' === strtolower( $response['status'] ) ) {
 					$this->update_status( $log_id, 'success' );
 
-					// Clear any scheduled retries.
-					wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
+					// Cancel any scheduled retries.
+					$this->cancel_scheduled_retry( $log_id );
 
 					wp_send_json_success(
 						array(
@@ -741,6 +790,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			// Increment attempts before trying.
 			$this->increment_resend_attempts( $log_id );
 
+			$this->is_retrying = true;
 			try {
 				$response = $api_class->create_entry( $settings, $lead_data, $log_id );
 
@@ -749,8 +799,8 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 					$this->update_status( $log_id, 'success' );
 					formscrm_debug_message( "Auto-retry SUCCESS for log {$log_id}: status updated to 'success'" );
 
-					// Clear any scheduled retries.
-					wp_clear_scheduled_hook( 'formscrm_retry_failed_entry', array( $log_id ) );
+					// Cancel any pending scheduled retries (AS + WP-Cron).
+					$this->cancel_scheduled_retry( $log_id );
 				} else {
 					$error_msg = isset( $response['message'] ) ? $response['message'] : 'Unknown error';
 					formscrm_debug_message( "Auto-retry FAILED for log {$log_id}: {$error_msg}" );
@@ -775,6 +825,8 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				} else {
 					formscrm_debug_message( "No more retries scheduled for log {$log_id}: max attempts reached" );
 				}
+			} finally {
+				$this->is_retrying = false;
 			}
 		}
 
@@ -832,12 +884,17 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 				$scheduled_time = $base_time + $index;
 
 				if ( function_exists( 'as_schedule_single_action' ) ) {
-					try {
-						as_schedule_single_action( $scheduled_time, 'formscrm_retry_failed_entry', array( $log_id ) );
-					} catch ( Exception $e ) {
-						wp_schedule_single_event( $scheduled_time, 'formscrm_retry_failed_entry', array( $log_id ) );
+					// Skip if a pending AS action already exists for this log.
+					if ( ! as_has_scheduled_action( 'formscrm_retry_failed_entry', array( $log_id ) ) ) {
+						try {
+							as_schedule_single_action( $scheduled_time, 'formscrm_retry_failed_entry', array( $log_id ) );
+						} catch ( Exception $e ) {
+							if ( ! wp_next_scheduled( 'formscrm_retry_failed_entry', array( $log_id ) ) ) {
+								wp_schedule_single_event( $scheduled_time, 'formscrm_retry_failed_entry', array( $log_id ) );
+							}
+						}
 					}
-				} else {
+				} elseif ( ! wp_next_scheduled( 'formscrm_retry_failed_entry', array( $log_id ) ) ) {
 					wp_schedule_single_event( $scheduled_time, 'formscrm_retry_failed_entry', array( $log_id ) );
 				}
 				++$index;

--- a/includes/admin/class-error-log.php
+++ b/includes/admin/class-error-log.php
@@ -51,6 +51,7 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 			add_action( 'wp_ajax_formscrm_export_csv', array( $this, 'ajax_export_csv' ) );
 			add_action( 'wp_ajax_formscrm_bulk_delete_logs', array( $this, 'ajax_bulk_delete_logs' ) );
 			add_action( 'wp_ajax_formscrm_bulk_resend_logs', array( $this, 'ajax_bulk_resend_logs' ) );
+			add_action( 'wp_ajax_formscrm_cancel_all_retries', array( $this, 'ajax_cancel_all_scheduled_retries' ) );
 
 			// Hook for automatic retry via Action Scheduler.
 			add_action( 'formscrm_retry_failed_entry', array( $this, 'retry_failed_entry' ), 10, 1 );
@@ -986,6 +987,32 @@ if ( ! class_exists( 'FORMSCRM_Error_Log' ) ) {
 					'failed'  => 0,
 				)
 			);
+		}
+
+		/**
+		 * AJAX handler to cancel all pending scheduled retries
+		 *
+		 * Removes every pending formscrm_retry_failed_entry action from both
+		 * Action Scheduler and WP-Cron without deleting any log entries.
+		 *
+		 * @return void
+		 */
+		public function ajax_cancel_all_scheduled_retries() {
+			check_ajax_referer( 'formscrm_error_log_nonce', 'nonce' );
+
+			if ( ! current_user_can( 'manage_options' ) ) {
+				wp_send_json_error( array( 'message' => __( 'Permission denied', 'formscrm' ) ) );
+			}
+
+			// Cancel all pending AS actions for this hook in one call.
+			if ( function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( 'formscrm_retry_failed_entry' );
+			}
+
+			// Clear WP-Cron fallback events (no args = clears all scheduled events for the hook).
+			wp_clear_scheduled_hook( 'formscrm_retry_failed_entry' );
+
+			wp_send_json_success( array( 'message' => __( 'All scheduled retries have been cancelled.', 'formscrm' ) ) );
 		}
 	}
 }

--- a/includes/admin/js/error-log.js
+++ b/includes/admin/js/error-log.js
@@ -311,6 +311,42 @@ document.addEventListener('DOMContentLoaded', function() {
 		});
 	}
 
+	// Cancel all scheduled retries.
+	const cancelAllRetriesBtn = document.getElementById('fcrm-cancel-all-retries');
+	if (cancelAllRetriesBtn) {
+		cancelAllRetriesBtn.addEventListener('click', function() {
+			if (!confirm(formscrmErrorLog.confirmCancelRetries)) {
+				return;
+			}
+
+			const originalText = this.textContent;
+			this.disabled = true;
+			this.textContent = formscrmErrorLog.cancellingRetries || 'Cancelling...';
+
+			const formData = new FormData();
+			formData.append('action', 'formscrm_cancel_all_retries');
+			formData.append('nonce', formscrmErrorLog.nonce);
+
+			fetch(formscrmErrorLog.ajaxurl, {
+				method: 'POST',
+				body: formData
+			})
+				.then(response => response.json())
+				.then(response => {
+					if (response.success) {
+						alert(response.data.message);
+					} else {
+						alert('Error: ' + (response.data.message || 'Failed to cancel retries'));
+					}
+				})
+				.catch(error => alert(formscrmErrorLog.ajaxError + ': ' + error))
+				.finally(() => {
+					this.disabled = false;
+					this.textContent = formscrmErrorLog.cancelAllRetries || originalText;
+				});
+		});
+	}
+
 	// Show bulk action progress.
 	function showBulkActionProgress(total, action) {
 		const bulkBtn = document.getElementById('fcrm-bulk-action-btn');

--- a/tests/phpstan-bootstrap.php
+++ b/tests/phpstan-bootstrap.php
@@ -440,6 +440,68 @@ function rgpost( $key ) {}
 function gform_add_meta( $form_id, $meta_key, $meta_value, $entry_id = 0 ) {}
 
 /**
+ * Action Scheduler Stubs
+ * ============================================================================
+ */
+
+if ( ! function_exists( 'as_schedule_single_action' ) ) {
+	/**
+	 * Schedule a single action.
+	 *
+	 * @param int    $timestamp Unix timestamp.
+	 * @param string $hook      Action hook.
+	 * @param array  $args      Action arguments.
+	 * @param string $group     Action group.
+	 * @return int
+	 */
+	function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+		return 0;
+	}
+}
+
+if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+	/**
+	 * Check if an action is scheduled.
+	 *
+	 * @param string $hook  Action hook.
+	 * @param array  $args  Action arguments.
+	 * @param string $group Action group.
+	 * @return bool
+	 */
+	function as_has_scheduled_action( $hook, $args = array(), $group = '' ) {
+		return false;
+	}
+}
+
+if ( ! function_exists( 'as_unschedule_all_actions' ) ) {
+	/**
+	 * Unschedule all pending actions for a hook.
+	 *
+	 * @param string $hook  Action hook.
+	 * @param array  $args  Action arguments.
+	 * @param string $group Action group.
+	 * @return void
+	 */
+	function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {}
+}
+
+/**
+ * Action Scheduler action object (minimal stub for type-checking).
+ */
+if ( ! class_exists( 'ActionScheduler_Action' ) ) {
+	class ActionScheduler_Action {
+		/**
+		 * Get the hook name.
+		 *
+		 * @return string
+		 */
+		public function get_hook() {
+			return '';
+		}
+	}
+}
+
+/**
  * WooCommerce Stubs
  * ============================================================================
  */


### PR DESCRIPTION
## Summary

This PR refactors the error log retry system to prevent duplicate Action Scheduler jobs and log entries during retry execution. It introduces explicit retry state tracking, consolidates scheduled action cancellation logic, and adds safeguards to prevent Action Scheduler from auto-retrying FormsCRM's retry hook.

## Key Changes

- **Add `$is_retrying` flag** — Prevents `insert_log()` from creating a new log row when `create_entry()` internally triggers `formscrm_alert_error()` during a retry, which would reset `resend_attempts` to 0 and schedule an extra job.

- **Consolidate retry cancellation** — Extract `cancel_scheduled_retry()` method to handle both Action Scheduler and WP-Cron cleanup in one place, replacing scattered `wp_clear_scheduled_hook()` calls.

- **Prevent duplicate scheduled actions** — Add `as_has_scheduled_action()` checks before scheduling new retry actions in `schedule_action_scheduler_retry()` and `ajax_bulk_resend_logs()` to avoid duplicate jobs.

- **Disable Action Scheduler auto-retry** — Add `disable_as_retry_for_formscrm()` filter hook to prevent Action Scheduler from automatically retrying the `formscrm_retry_failed_entry` action; FormsCRM manages retry scheduling explicitly via `schedule_retry()`.

- **Improve error handling** — Add debug logging when Action Scheduler scheduling fails before falling back to WP-Cron; check for existing WP-Cron jobs before scheduling.

- **Add Action Scheduler stubs** — Extend `tests/phpstan-bootstrap.php` with stubs for `as_schedule_single_action()`, `as_has_scheduled_action()`, `as_unschedule_all_actions()`, and `ActionScheduler_Action` class for PHPStan type-checking.

## Implementation Details

- The `$is_retrying` flag is set to `true` before calling `create_entry()` in `retry_failed_entry()` and reset to `false` in a `finally` block to ensure cleanup even if an exception occurs.
- All scheduled action cancellations now use the centralized `cancel_scheduled_retry()` method, which handles both AS and WP-Cron in a single call.
- The retry scheduling logic now checks for existing actions before creating new ones, preventing the 3-attempt cap from being bypassed by duplicate jobs.

https://claude.ai/code/session_01V3GxnHHrfyoXhSwqFBnrcj

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22%24schema%22%3A%22https%3A%2F%2Fplayground.wordpress.net%2Fblueprint-schema.json%22%2C%22landingPage%22%3A%22%2Fwp-admin%2Foptions-general.php%3Fpage%3Dformscrm%22%2C%22phpExtensionBundles%22%3A%5B%22kitchen-sink%22%5D%2C%22steps%22%3A%5B%7B%22step%22%3A%22login%22%2C%22username%22%3A%22admin%22%2C%22password%22%3A%22password%22%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22wordpress.org%2Fplugins%22%2C%22slug%22%3A%22contact-form-7%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%2C%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2Fclosemarketing%2Fformscrm%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-225-36d6a4542bc03d9485d6da357398f5ec2e24dc93.zip%22%7D%2C%22options%22%3A%7B%22activate%22%3Atrue%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->